### PR TITLE
Removing references to unused google_analytics properties

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,8 +63,8 @@ header_pages:
 
 
 google_analytics:
-  - UA-185058308-1 # Old GA Universal Analytics property
-  - G-RY6FRPMXHZ # New GA4 property
+#  - UA-185058308-1 # Old GA Universal Analytics property
+#  - G-RY6FRPMXHZ # New GA4 property
 
 gravatar_hash: 2136e716a089f4a3794f4007328c7bfb
 code_block_max_height: 500px


### PR DESCRIPTION
When you forked my repo, you also copied my google analytics properties. Please remove them so that it is not interfering with my google analytics statistics.

If your interest is to build a blog, I would recommend following the blog post as written, which provides a template you can use to create a blog. Forking my repo is not the correct way to do it.

https://chadbaldwin.net/2021/03/14/how-to-build-a-sql-blog.html