### PR TITLE
Fix the dark-mode theme conflicts on <html>, and finish the giscus migration

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -72,21 +72,25 @@ an HTML link check.
 > there is no `libcurl.dll`. It works on the Linux CI runner, so let the PR
 > build do that check.
 
-## Enabling giscus comments
+## Comments
 
-Comments currently fall back to Disqus. To switch to
-[giscus](https://giscus.app) (GitHub Discussions-backed, no ads or trackers):
+Comments are [giscus](https://giscus.app), backed by GitHub Discussions — no ads
+or trackers. Threads live in the repository's **Announcements** category, which is
+announcement-format, so only maintainers can open a thread and readers cannot
+create discussions just by visiting a post.
 
-1. Enable **Discussions** on the repository.
-2. Add a category named **Comments** of type **Announcement** — giscus requires
-   Announcement so that only you can open threads.
-3. Install the [giscus app](https://github.com/apps/giscus) for this repository.
-4. Get `repo_id` and `category_id` from <https://giscus.app> and uncomment them
-   under `giscus:` in `_config.yml`.
-5. Remove the `disqus:` key.
+`_includes/comments.html` switches on `giscus.repo_id` **and** `giscus.category_id`
+both being set, and otherwise falls back to a Disqus embed. Deleting either id from
+`_config.yml` and restoring `disqus: 'https-danghoangnhan-github-io'` is therefore a
+complete rollback.
 
-There is no import path from Disqus to giscus, so check the Disqus admin for
-anything worth keeping first.
+The theme is not left to giscus. `data-theme="preferred_color_scheme"` would make
+the comment iframe follow the OS while the page follows the reader's stored choice,
+so `_includes/comments.html` builds the giscus `<script>` in JS and sets the
+resolved theme on it, and `assets/js/theme.js` re-syncs it over `postMessage`.
+
+There is no import path from Disqus to giscus, so anything worth keeping from the
+old threads has to come out of the Disqus admin by hand.
 
 ## Writing a post
 

--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,9 @@ url: "https://danghoangnhan.github.io"
 baseurl: ""
 lang: en
 
-disqus: 'https-danghoangnhan-github-io'
+# `disqus:` removed — comments moved to giscus (see below). The old shortname was
+# 'https-danghoangnhan-github-io'; restoring that key is all it takes to roll back,
+# since _includes/comments.html still falls through to Disqus when giscus is unset.
 
 include: ["_pages"]
 permalink: /:title/
@@ -75,20 +77,23 @@ google_analytics:
 # The github repo used for looking up comments
 comments_repo: danghoangnhan/danghoangnhan.github.io
 
-# giscus (GitHub Discussions-backed comments).
-# Until repo_id and category_id are filled in, _includes/comments.html falls
-# back to the Disqus embed above, so comments keep working either way.
-# To switch over:
-#   1. Enable Discussions on the repo and add a category named "Comments"
-#      of type Announcement (giscus requires Announcement).
-#   2. Install the giscus app: https://github.com/apps/giscus
-#   3. Get the two ids from https://giscus.app and paste them below.
-#   4. Remove the `disqus:` key above.
+# giscus (GitHub Discussions-backed comments). Active: _includes/comments.html
+# switches to giscus once both ids are present, and falls back to the Disqus embed
+# otherwise — so deleting either id below is a complete rollback.
+#
+# "Announcements" is GitHub's default announcement-format category, which is what
+# giscus wants: only maintainers can open threads there, so readers cannot create
+# discussions by visiting a post. Blog threads therefore share the category with
+# any real announcements; move them to a dedicated Announcement-format category if
+# that ever gets noisy.
+#
+# Both ids read from the GitHub API — repo_id from `GET /repos/{owner}/{repo}`,
+# category_id from the GraphQL discussionCategories query.
 giscus:
   repo: danghoangnhan/danghoangnhan.github.io
-  category: Comments
-#  repo_id: R_xxxxxxxxxx
-#  category_id: DIC_xxxxxxxxxx
+  category: Announcements
+  repo_id: R_kgDOGfn8Uw
+  category_id: DIC_kwDOGfn8U84DCdF8
 
 titles_from_headings:
   strip_title: true

--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -6,28 +6,58 @@
   threading nor reactions; giscus uses Discussions instead. (Same author —
   giscus is the successor.)
 
-  giscus needs a repo_id and category_id that can only be obtained after
-  enabling Discussions and installing the giscus app, so until `giscus:` is
-  filled in in _config.yml this falls back to the existing Disqus embed and
-  comments never simply vanish. Setup steps are in the README.
+  The gate below needs BOTH ids, so deleting either from _config.yml (and
+  restoring the `disqus:` key) falls straight back to the Disqus embed rather
+  than leaving posts with no comments at all.
 {%- endcomment -%}
 {%- if site.giscus and site.giscus.repo_id and site.giscus.category_id -%}
-<div class="no-print">
-  <script src="https://giscus.app/client.js"
-          data-repo="{{ site.giscus.repo | default: site.comments_repo }}"
-          data-repo-id="{{ site.giscus.repo_id }}"
-          data-category="{{ site.giscus.category | default: 'Comments' }}"
-          data-category-id="{{ site.giscus.category_id }}"
-          data-mapping="pathname"
-          data-strict="1"
-          data-reactions-enabled="1"
-          data-emit-metadata="0"
-          data-input-position="top"
-          data-theme="preferred_color_scheme"
-          data-lang="en"
-          data-loading="lazy"
-          crossorigin="anonymous"
-          async>
+<div class="no-print" id="giscus-container">
+  {%- comment -%}
+    Built programmatically rather than as a static <script> tag, following the
+    same pattern as _includes/disqus.html.
+
+    The reason is data-theme. It used to be "preferred_color_scheme", which makes
+    the comment iframe follow the OS rather than the site — so a reader who picks
+    light on a dark machine gets a light page with dark comments. It cannot be
+    emitted by Liquid either, since the choice lives in localStorage.
+
+    Creating the element here lets us read the already-resolved theme off <html>
+    synchronously (theme-head.html ran in <head>, so the attribute is always
+    present) and set it before giscus ever loads. Patching the attribute on a
+    static async tag from a following inline script would instead be a race:
+    async scripts execute whenever their fetch completes, and winning by a
+    microsecond is an implementation detail, not a guarantee.
+
+    assets/js/theme.js keeps it in sync afterwards, via postMessage on toggle
+    plus a one-shot re-send once giscus signals it has booted.
+  {%- endcomment -%}
+  <script>
+    (function () {
+      var config = {
+        "data-repo": {{ site.giscus.repo | default: site.comments_repo | jsonify }},
+        "data-repo-id": {{ site.giscus.repo_id | jsonify }},
+        "data-category": {{ site.giscus.category | default: 'Comments' | jsonify }},
+        "data-category-id": {{ site.giscus.category_id | jsonify }},
+        "data-mapping": "pathname",
+        "data-strict": "1",
+        "data-reactions-enabled": "1",
+        "data-emit-metadata": "0",
+        "data-input-position": "top",
+        "data-lang": "en",
+        "data-loading": "lazy",
+        "data-theme":
+          document.documentElement.dataset.theme === "dark" ? "dark" : "light"
+      };
+
+      var s = document.createElement("script");
+      s.src = "https://giscus.app/client.js";
+      s.async = true;
+      s.crossOrigin = "anonymous";
+      Object.keys(config).forEach(function (key) {
+        s.setAttribute(key, config[key]);
+      });
+      document.getElementById("giscus-container").appendChild(s);
+    })();
   </script>
   <noscript>Comments require JavaScript.</noscript>
 </div>

--- a/_includes/theme-head.html
+++ b/_includes/theme-head.html
@@ -1,21 +1,68 @@
 {%- comment -%}
-  Applies the stored theme before first paint.
+  Applies the stored theme before first paint, and owns the theme contract.
 
   This has to be inline and synchronous in <head>. A deferred script would run
   after the browser has already painted a light page, giving a visible white
   flash to anyone reading in dark mode.
+
+  It also publishes `window.siteTheme`, which assets/js/theme.js consumes. That
+  keeps the attribute write, the storage key and the resolution rule defined in
+  exactly one place — an inline pre-paint script and a deferred external file
+  cannot share code any other way without a module loader.
 {%- endcomment -%}
 <script>
   (function () {
-    try {
-      var pref = localStorage.getItem("theme");
-      var dark =
-        pref === "dark" ||
-        (pref !== "light" &&
-          window.matchMedia("(prefers-color-scheme: dark)").matches);
-      var theme = dark ? "dark" : "light";
-      document.documentElement.dataset.theme = theme;
-      document.documentElement.setAttribute("data-bs-theme", theme);
-    } catch (e) {}
+    var STORAGE_KEY = "theme";
+
+    function stored() {
+      // Access can throw outright in some privacy configurations, not just
+      // return null, so this needs a guard rather than a falsy check.
+      try {
+        return localStorage.getItem(STORAGE_KEY);
+      } catch (e) {
+        return null;
+      }
+    }
+
+    function store(theme) {
+      try {
+        localStorage.setItem(STORAGE_KEY, theme);
+      } catch (e) {
+        /* private mode: the choice just won't persist across loads */
+      }
+    }
+
+    function systemPrefersDark() {
+      return window.matchMedia("(prefers-color-scheme: dark)").matches;
+    }
+
+    function resolve() {
+      var pref = stored();
+      if (pref === "dark" || pref === "light") return pref;
+      return systemPrefersDark() ? "dark" : "light";
+    }
+
+    // The only place in the codebase that writes the theme attributes.
+    function set(theme) {
+      var el = document.documentElement;
+      el.dataset.theme = theme;
+      // Bootstrap 5.3 recolours its own utilities from this attribute, which is
+      // most of why dark mode here is short instead of a full palette rewrite.
+      el.setAttribute("data-bs-theme", theme);
+    }
+
+    window.siteTheme = {
+      set: set,
+      store: store,
+      stored: stored,
+      resolve: resolve,
+    };
+
+    // Deliberately NOT inside a try/catch. The reads above already fail safe, and
+    // _sass/_theme-scope.scss reads a *missing* data-theme as "JS never ran" and
+    // hands the decision to prefers-color-scheme. Leaving the attribute unset
+    // after JS has run would silently override an explicit light choice whenever
+    // the OS is dark.
+    set(resolve());
   })();
 </script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -69,9 +69,13 @@
   <body class="{{ layout }}">
     <!-- Begin Menu Navigation
 ================================================== -->
+    <!-- No data-bs-theme here. Bootstrap 5.3 resolves it at the nearest ancestor,
+         so pinning the nav to "light" reset every --bs-* variable back to the light
+         palette for this whole subtree while _dark.scss forced the bar dark anyway —
+         most visibly a black toggler border and focus ring on a #161b22 bar. The nav
+         inherits the correct theme from <html>. -->
     <nav
       class="navbar navbar-expand-lg bg-white fixed-top mediumnavigation nav-down"
-      data-bs-theme="light"
     >
       <div class="container pe-0">
         <!-- Begin Logo -->
@@ -255,10 +259,17 @@
     <script defer src="{{ '/assets/js/copy-code.js' | relative_url }}"></script>
     {%- endif %}
 
+    {%- comment -%}
+      Disqus comment-count script, only emitted on the Disqus fallback path.
+      Unguarded this resolved to https://.disqus.com/count.js — a request to a
+      nonexistent host on every page — as soon as `disqus:` left _config.yml.
+    {%- endcomment -%}
+    {%- if site.disqus %}
     <script
       id="dsq-count-scr"
       src="https://{{ site.disqus }}.disqus.com/count.js"
     ></script>
+    {%- endif %}
 
     <!-- KaTeX -->
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.47/dist/katex.min.js" integrity="sha384-CwjPRVHTvLiMBFjEoij+QZViMV5rhTOIp7CJzl24JEqpRDA1sJFHVXXLURktbYYp" crossorigin="anonymous" referrerpolicy="no-referrer"></script>

--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -2,6 +2,8 @@
 // screen.css is the original vendored theme stylesheet and is left untouched;
 // everything new lives here so the two never fight over ownership.
 
+@use "theme-scope" as *;
+
 $rule: #eaeaea;
 $muted: rgba(0, 0, 0, 0.55);
 $accent: #0a2b46;
@@ -233,9 +235,11 @@ $accent: #0a2b46;
   }
 }
 
-[data-theme="dark"] .theme-toggle {
-  .theme-icon-dark { display: inline-block; }
-  .theme-icon-light { display: none; }
+@include when-dark {
+  .theme-toggle {
+    .theme-icon-dark { display: inline-block; }
+    .theme-icon-light { display: none; }
+  }
 }
 
 // ---------------------------------------------------------- post left rail

--- a/_sass/_dark.scss
+++ b/_sass/_dark.scss
@@ -12,6 +12,8 @@
 // DarkReader, which the repo previously attempted, is deliberately not used:
 // runtime CSS inversion mangles SVG diagrams, Mermaid output and KaTeX.
 
+@use "theme-scope" as *;
+
 $bg: #0d1117;
 $surface: #161b22;
 $text: #c9d1d9;
@@ -20,7 +22,10 @@ $rule: #30363d;
 $link: #79c0ff;
 $link-hover: #a5d6ff;
 
-[data-theme="dark"] {
+@include when-dark {
+  // Hands scrollbars, form-control internals and default UA widget chrome to
+  // the browser. Worth noting this works in the no-JS branch too, where
+  // Bootstrap's own variables are out of reach.
   color-scheme: dark;
 
   body {
@@ -167,12 +172,23 @@ $link-hover: #a5d6ff;
     color: $text-muted;
   }
 
+  // The rail and the active marker take $rule (#eaeaea) and $accent (#0a2b46)
+  // from _components.scss. Unoverridden that is a near-white 2px line and an
+  // almost-invisible navy marker against #0d1117.
+  .toc-list {
+    border-left-color: $rule;
+  }
+
   .toc-list a {
     color: $text-muted;
 
-    &:hover,
+    &:hover {
+      color: $link;
+    }
+
     &.is-active {
       color: $link;
+      border-left-color: $link;
     }
   }
 
@@ -190,6 +206,12 @@ $link-hover: #a5d6ff;
   .theme-toggle {
     border-color: $rule;
     color: $text;
+
+    // _components.scss hovers this to #f6f8fa: a near-white pill carrying
+    // light-grey icons, i.e. the button vanishes exactly when you point at it.
+    &:hover {
+      background: #21262d;
+    }
   }
 
   // Mermaid renders its own SVG palette via the theme passed to
@@ -197,5 +219,34 @@ $link-hover: #a5d6ff;
   // surface so transparent diagram backgrounds do not float on pure black.
   .mermaid svg {
     background: transparent;
+  }
+}
+
+// --- Bootstrap fallback, JS-off only --------------------------------------
+//
+// With JS off nothing writes data-bs-theme, so Bootstrap stays on the light
+// variable set from `:root,[data-bs-theme=light]` even on a dark OS. The double
+// :not() targets exactly that case — with JS on, Bootstrap's own
+// [data-bs-theme=dark] block already handles all of this.
+//
+// Only the properties this site actually consumes are re-declared; duplicating
+// Bootstrap's full ~200-property dark palette would just rot on the next upgrade.
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme]):not([data-bs-theme]) {
+    --bs-emphasis-color: #fff;
+    --bs-emphasis-color-rgb: 255, 255, 255;
+    --bs-body-color: #dee2e6;
+    --bs-body-color-rgb: 222, 226, 230;
+    --bs-border-color: #495057;
+    --bs-secondary-color: rgba(222, 226, 230, 0.75);
+
+    // .navbar derives its toggler border and colour from --bs-emphasis-color-rgb
+    // above, so those follow. The icon cannot: it is a data-URI with the stroke
+    // baked in, swapped by `[data-bs-theme=dark] .navbar-toggler-icon`, which has
+    // no attribute to match here. Left alone it is a near-black hamburger on a
+    // #161b22 bar. Copied verbatim from Bootstrap 5.3.8 so it cannot drift.
+    .navbar-toggler-icon {
+      --bs-navbar-toggler-icon-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28255, 255, 255, 0.55%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+    }
   }
 }

--- a/_sass/_syntax-dark.scss
+++ b/_sass/_syntax-dark.scss
@@ -5,7 +5,9 @@
 // Roughly the GitHub Dark token colours, chosen so contrast against #0d1117
 // stays above WCAG AA for body-size text.
 
-[data-theme="dark"] {
+@use "theme-scope" as *;
+
+@include when-dark {
   .highlight,
   pre.highlight {
     background-color: #0d1117;

--- a/_sass/_theme-scope.scss
+++ b/_sass/_theme-scope.scss
@@ -1,0 +1,36 @@
+// Emits a block of dark-theme rules under every selector that should get them.
+//
+// Two branches, because there are two ways a reader ends up in dark mode:
+//
+//   1. html[data-theme="dark"]         — JS ran and resolved to dark.
+//   2. the prefers-color-scheme branch — JS never ran (disabled, blocked, or it
+//                                        failed to load) and the OS is dark.
+//
+// Branch 2 is reachable ONLY when JS did not run: _includes/theme-head.html
+// writes data-theme unconditionally, outside any try/catch, precisely so that a
+// present-but-"light" attribute can veto a dark OS. Do not "simplify" either
+// half of that invariant — dropping it makes an explicit light choice on a dark
+// machine silently flip to dark.
+//
+// The `html` qualifier is not cosmetic. _includes/comments.html puts a real
+// data-theme on the giscus <script> tag, which a bare [data-theme="dark"] would
+// match. It also turns a source-order tie against screen.css's
+// `a.text-dark { color: #0a2b46 !important }` into an outright specificity win.
+//
+// KNOWN LIMIT (branch 2 only): Bootstrap's own dark palette lives under
+// [data-bs-theme=dark] and cannot be reached from a media query without
+// duplicating all ~200 of its custom properties. Today that is invisible here
+// because the site uses almost no Bootstrap components, and _dark.scss re-styles
+// the few it does use. Add a Bootstrap dropdown, modal or alert and it will
+// render light-on-dark for readers without JS.
+@mixin when-dark {
+  html[data-theme="dark"] {
+    @content;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    html:not([data-theme="light"]) {
+      @content;
+    }
+  }
+}

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,46 +1,47 @@
 /*
  * Theme toggle: light / dark / follow-system.
  *
- * The initial read is inlined in <head> (see _includes/theme-head.html) so the
- * correct theme is applied before first paint. This file only handles the
- * toggle button and broadcasting changes.
- *
- * Consumers subscribing to the `themechange` event: mermaid (it bakes colours
- * into generated SVG) and giscus (via postMessage).
+ * The theme contract itself — reading the preference, writing the attributes —
+ * lives in _includes/theme-head.html, which has to run inline before first paint.
+ * This file consumes it through window.siteTheme and owns the toggle button plus
+ * the two consumers that CSS cannot reach: mermaid (it bakes colours into the
+ * generated SVG) and giscus (it renders in a cross-origin iframe).
  */
 (function () {
   "use strict";
 
-  var STORAGE_KEY = "theme";
-  var root = document.documentElement;
+  var T = window.siteTheme;
+  // theme-head.html missing: degrade to "no toggle" rather than throwing and
+  // taking the rest of the page's scripts down with us.
+  if (!T) return;
 
-  function systemPrefersDark() {
-    return window.matchMedia("(prefers-color-scheme: dark)").matches;
+  var GISCUS_ORIGIN = "https://giscus.app";
+
+  // theme-head.html already wrote this before first paint, so it is the theme the
+  // page actually rendered with — the baseline for "did anything change".
+  var current = document.documentElement.dataset.theme;
+
+  // Last theme we told giscus about, so we can tell stale from in-sync below.
+  var giscusTheme = null;
+
+  function sendGiscusTheme(theme) {
+    var frame = document.querySelector("iframe.giscus-frame");
+    if (!frame || !frame.contentWindow) return;
+    frame.contentWindow.postMessage(
+      { giscus: { setConfig: { theme: theme } } },
+      GISCUS_ORIGIN
+    );
+    giscusTheme = theme;
   }
 
-  function stored() {
-    try {
-      return localStorage.getItem(STORAGE_KEY);
-    } catch (e) {
-      return null;
-    }
-  }
-
-  function resolved() {
-    var pref = stored();
-    if (pref === "dark" || pref === "light") return pref;
-    return systemPrefersDark() ? "dark" : "light";
-  }
-
-  function apply(theme) {
-    root.dataset.theme = theme;
-    // Bootstrap 5.3 recolours its own utilities from this attribute, which is
-    // most of why dark mode here is 60 lines instead of 250.
-    root.setAttribute("data-bs-theme", theme);
+  // Everything that has to happen alongside the attribute write. isDark is
+  // computed once at the top: it used to be declared inside `if (button)` and
+  // read further down, so it was undefined whenever the toggle was absent.
+  function syncDependents(theme) {
+    var isDark = theme === "dark";
 
     var button = document.getElementById("theme-toggle");
     if (button) {
-      var isDark = theme === "dark";
       button.setAttribute("aria-pressed", String(isDark));
       button.setAttribute(
         "aria-label",
@@ -48,32 +49,35 @@
       );
     }
 
-    document.dispatchEvent(
-      new CustomEvent("themechange", { detail: { theme: theme } })
-    );
-
-    // giscus renders in an iframe and cannot read our CSS.
-    var frame = document.querySelector("iframe.giscus-frame");
-    if (frame && frame.contentWindow) {
-      frame.contentWindow.postMessage(
-        { giscus: { setConfig: { theme: isDark ? "dark" : "light" } } },
-        "https://giscus.app"
+    // Only on an actual change. The DOMContentLoaded call below re-applies the
+    // theme the page already painted with, and firing themechange for that made
+    // _includes/mermaid.html throw away and re-render every diagram, identically,
+    // on every load of a diagram post.
+    if (theme !== current) {
+      current = theme;
+      document.dispatchEvent(
+        new CustomEvent("themechange", { detail: { theme: theme } })
       );
     }
+
+    sendGiscusTheme(theme);
+  }
+
+  function apply(theme) {
+    T.set(theme);
+    syncDependents(theme);
   }
 
   function toggle() {
-    var next = resolved() === "dark" ? "light" : "dark";
-    try {
-      localStorage.setItem(STORAGE_KEY, next);
-    } catch (e) {
-      /* private mode: theme just won't persist */
-    }
+    var next = T.resolve() === "dark" ? "light" : "dark";
+    T.store(next);
     apply(next);
   }
 
   document.addEventListener("DOMContentLoaded", function () {
-    apply(resolved());
+    // The attribute write is redundant here (theme-head.html already did it) but
+    // idempotent, and it is the one path that self-heals if that write was lost.
+    apply(T.resolve());
     var button = document.getElementById("theme-toggle");
     if (button) button.addEventListener("click", toggle);
   });
@@ -82,6 +86,20 @@
   window
     .matchMedia("(prefers-color-scheme: dark)")
     .addEventListener("change", function () {
-      if (!stored()) apply(resolved());
+      if (!T.stored()) apply(T.resolve());
     });
+
+  // The giscus iframe is data-loading="lazy", so its document does not load until
+  // it scrolls into view, and setConfig sent before that is dropped. Any message
+  // from the frame proves it is live, so reconcile then.
+  //
+  // The staleness guard is load-bearing: setConfig triggers a re-render, which
+  // emits resizeHeight, which would otherwise trigger another setConfig. It also
+  // covers toggling the theme while the frame is still unloaded.
+  window.addEventListener("message", function (event) {
+    if (event.origin !== GISCUS_ORIGIN) return;
+    if (!event.data || typeof event.data !== "object" || !event.data.giscus) return;
+    var theme = T.resolve();
+    if (giscusTheme !== theme) sendGiscusTheme(theme);
+  });
 })();


### PR DESCRIPTION
## What was wrong

`<html>` carried **both** `data-theme` and `data-bs-theme`, written in lockstep from two separate files — and `_layouts/default.html` then hardcoded `data-bs-theme="light"` on the `<nav>`. Bootstrap 5.3 resolves that attribute at the nearest ancestor, so the navbar got the **light** variable set inside a dark document, while `_sass/_dark.scss` forced its background dark anyway.

`git log -S` shows the attribute arrived in `ecb3e27` as a mechanical Bootstrap 4→5 rename of `navbar-light` — **before dark mode existed**. It was never a deliberate choice; it became a bug when dark mode landed.

## What it actually broke

I verified against the real `bootstrap@5.3.8` dist rather than from memory, which ruled out two plausible-sounding symptoms:

- The **hamburger icon was always fine** — `[data-bs-theme=dark] .navbar-toggler-icon` is a descendant selector, so it matches via the `<html>` ancestor no matter what the nav says.
- The **flattened active nav link is not this bug** — `screen.css`'s `a { color: #0a2b46 !important }` overrides Bootstrap's active colour in *light* mode too. Pre-existing, left alone.

What it did break, keyboard-only and below 992px: `.navbar-toggler:focus` sets no shadow colour, so the ring fell back to `currentColor` = `rgba(0,0,0,.65)` — **a black focus ring on a near-black bar**. Plus an invisible toggler border.

## Also fixed

| | |
|---|---|
| **One writer** | `theme-head.html` owns the contract and publishes `window.siteTheme`; `theme.js` consumes it. Its `try/catch` also wrapped the *whole* block, so a `localStorage` throw left **no attribute at all** — now only the storage read is guarded. |
| **`isDark` scoping** | Declared inside `if (button)`, read outside it — giscus was told `"light"` on a dark page whenever the toggle was absent. |
| **giscus theme** | Was pinned to `preferred_color_scheme`, i.e. the OS rather than the reader's stored choice. Now built programmatically with the resolved theme — patching an `async` tag from a following inline script is a race, not a guarantee — plus a staleness-guarded resync, since the lazy iframe drops early messages. |
| **No-JS dark mode** | A `when-dark` mixin emits both an attribute branch and a `prefers-color-scheme` branch. The media branch is reachable *only* when JS did not run, which is exactly why the attribute write had to become unconditional. |

Four more dark-mode bugs found on the way: the theme toggle turned near-white on hover (invisible), the TOC rail rendered `#eaeaea` and its active marker `#0a2b46` on `#0d1117`, and **mermaid re-rendered every diagram twice per load** because `theme.js` dispatched `themechange` for its own redundant re-apply.

## giscus migration

Discussions is enabled and the app is installed, so the Disqus fallback is retired. Threads live in the default **Announcements** category — announcement-format, so only maintainers can open a thread and readers can't create discussions by visiting a post.

Install was confirmed, not assumed: repos without the app (`torvalds/linux`, `rails/rails`) return `"giscus is not installed on this repository"`; this repo returns `"Discussion not found"` — resolved, just no thread on that page yet.

Removing `disqus:` exposed a latent bug — the comment-count script interpolated `site.disqus` unguarded, so dropping the key would have made every page request `https://.disqus.com/count.js`. **The guard is in the first commit and the key removal in the second**, so the ordering can't regress.

Rollback is deleting either giscus id and restoring the `disqus:` key; the gate needs both ids and falls through otherwise. The old shortname is kept in a comment for that reason.

## Verification

- **Light mode is provably unchanged** — stripping every dark block from the compiled CSS leaves **602 identical lines** before and after.
- Zero `data-bs-theme="light"` in the build; clean Sass compile, no deprecation warnings.
- The giscus block was dead code, so I built once with dummy ids to confirm it renders — it does, and the gate suppresses Disqus correctly.

**Not verified visually** — no browser tooling available here. Worth a human pass: the giscus widget rendering, dark mode below 992px (tab to the hamburger — that focus ring was the actual bug), and the JS-disabled path with the OS set to dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
