### PR TITLE
fix: resolve dark-mode theme conflicts, post-card colours and the post rail collision

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -55,10 +55,14 @@
       referrerpolicy="no-referrer"
     />
 
-    <link href="{{ '/assets/css/screen.css' | relative_url }}" rel="stylesheet" />
+    <!-- The ?v= is not cosmetic: main.css overrides rules in screen.css, so a
+         visitor holding one from cache and one fresh gets a broken page — most
+         visibly .share reverting to screen.css's position:fixed on top of the
+         table of contents. site.time changes on every build. -->
+    <link href="{{ '/assets/css/screen.css' | relative_url }}?v={{ site.time | date: '%s' }}" rel="stylesheet" />
     <!-- main.css, NOT main.scss: Jekyll compiles the .scss source to .css, so
          linking the source extension 404s and the Rouge syntax theme never loads. -->
-    <link href="{{ '/assets/css/main.css' | relative_url }}" rel="stylesheet" />
+    <link href="{{ '/assets/css/main.css' | relative_url }}?v={{ site.time | date: '%s' }}" rel="stylesheet" />
 
     {% if jekyll.environment == 'production' and site.google_analytics %}
       {% include google-analytics.html %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,7 +13,11 @@ post_class: post-template
 		<!-- Left rail: share buttons and, on long posts, the table of contents.
 		     screen.css pins .share with position:fixed above 1024px, which would
 		     overlap anything placed beneath it — so the rail is a single sticky
-		     container instead, and _components.scss unsets that fixed rule. -->
+		     container instead, and _components.scss unsets that fixed rule.
+		     The rail itself never scrolls: it is a flex column that gives .share
+		     its natural height and hands the rest to the TOC, whose link list
+		     owns the only scrollbar. Keep that order — .share first — or the
+		     share block scrolls away with the headings on a long post. -->
 		<div class="col-md-2 ps-0">
 			<div class="post-rail">
 				{% include share.html %}

--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -8,6 +8,14 @@ $rule: #eaeaea;
 $muted: rgba(0, 0, 0, 0.55);
 $accent: #0a2b46;
 
+// The post rail turns into a sticky column at the same width screen.css:306
+// uses to pin .share. Both bounds are declared here so the "rail" and "no rail"
+// rules can never disagree: `max-width: 1023px` against `min-width: 1024px`
+// leaves the open interval between them matching neither, which browser zoom
+// and 125%/150% display scaling land in routinely.
+$rail-bp: 1024px;
+$rail-bp-max: 1023.98px;
+
 // ---------------------------------------------------------------- utilities
 
 .visually-hidden {
@@ -247,15 +255,25 @@ $accent: #0a2b46;
 // screen.css pins .share with `position: fixed` above 1024px. That was fine
 // when the rail held nothing else, but the TOC has to sit beneath it — so the
 // rail becomes one sticky column and the fixed rule is unset.
+//
+// The rail deliberately does NOT scroll. It caps at the viewport and hands the
+// leftover height to the TOC, which owns the only scrollbar (see .toc-list).
+// When the rail scrolled instead, a long TOC dragged the whole share block out
+// of view — the two contended for one 148px box. `overflow-y: auto` here also
+// computed overflow-x to `auto` per CSS Overflow 3 §3.1, clipping horizontally.
 .post-rail {
-  @media (min-width: 1024px) {
+  @media (min-width: $rail-bp) {
     position: sticky;
     top: 90px;
     max-height: calc(100vh - 110px);
-    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
 
+    // Unsets screen.css:308. Scoped to the rail so the vendored rule still
+    // applies if .share is ever used somewhere else.
     .share {
       position: static;
+      flex: 0 0 auto;
     }
   }
 }
@@ -267,11 +285,27 @@ $accent: #0a2b46;
   font-size: 0.8rem;
   text-align: left;
 
+  // (0,2,0), so it still beats the `display: flex` below whatever the order.
   &[hidden] { display: none; }
+
+  @media (min-width: $rail-bp) {
+    // Take the height the share block leaves behind, then split it again
+    // between a fixed heading and a scrolling list.
+    flex: 1 1 auto;
+    min-height: 0; // a flex item will not shrink below its content without this
+    display: flex;
+    flex-direction: column;
+
+    // .share is centred, the TOC is left-aligned, and 1.5rem of margin was the
+    // only thing between them — in a 148px column the two read as one blob.
+    border-top: 1px solid $rule;
+    margin-top: 1.25rem;
+    padding-top: 1.25rem;
+  }
 
   // Below the sticky breakpoint the rail stacks above the article, where a long
   // TOC would push the post itself off-screen.
-  @media (max-width: 1023px) {
+  @media (max-width: $rail-bp-max) {
     display: none;
   }
 }
@@ -282,6 +316,11 @@ $accent: #0a2b46;
   font-size: 0.68rem;
   color: $muted;
   margin-bottom: 0.4rem;
+
+  // Stays put while the list below it scrolls.
+  @media (min-width: $rail-bp) {
+    flex: 0 0 auto;
+  }
 }
 
 .toc-list {
@@ -289,6 +328,16 @@ $accent: #0a2b46;
   padding: 0;
   margin: 0;
   border-left: 2px solid $rule;
+
+  // The rail's only scrollbar. A 27-heading post runs to roughly 1100px of
+  // links against 350-700px of usable rail, so this has to scroll somewhere —
+  // here it does so without taking the share block or the heading with it.
+  @media (min-width: $rail-bp) {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain; // don't hand the scroll to the page at the ends
+  }
 
   li { margin: 0; }
 
@@ -311,6 +360,40 @@ $accent: #0a2b46;
       font-weight: 600;
     }
   }
+}
+
+// The navbar is fixed-top and ~57px tall, so a TOC link would otherwise scroll
+// its heading to y=0 and straight underneath it. Same offset the topic and
+// archive headings already use above.
+.article-post {
+  h2,
+  h3,
+  h4 {
+    scroll-margin-top: 80px;
+  }
+}
+
+// ------------------------------------------------------------------- share
+
+// screen.css:295 styles the share icons as 30px bordered circles via
+// `.share ul li i.fa`, but the markup emits `i.fab` — in Font Awesome 6+ `fab`
+// is its own class rather than a modifier on `fa`, so that rule stopped
+// matching at the v4 -> v7 upgrade and the circles silently disappeared.
+.share ul li i.fab {
+  border: 1px solid $rule;
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+  text-align: center;
+  border-radius: 50%;
+}
+
+// The "Read Story" bookmark in every post card footer is an inline <svg> with
+// no `fill` attribute and no rule setting one, so it painted UA-default black —
+// invisible against a dark card. Inheriting the link colour fixes dark mode and
+// matches what screen.css:386 already does for the share icons in light.
+.svgIcon-use {
+  fill: currentColor;
 }
 
 // ------------------------------------------------------------------ series

--- a/_sass/_dark.scss
+++ b/_sass/_dark.scss
@@ -74,15 +74,84 @@ $link-hover: #a5d6ff;
     border-color: $rule;
   }
 
+  // --- post cards ---------------------------------------------------------
+  //
+  // .card above is a Bootstrap utility, so data-bs-theme covers most of it. The
+  // rules below are all Mediumish's own, which Bootstrap knows nothing about.
+
+  // The featured card's outer wrapper. Its rgba(10,43,70,.3) border composites
+  // to roughly #0b1420 over #0d1117, so the outline vanishes, and it carries no
+  // background of its own — it stayed page-coloured while the .card nested
+  // inside it was forced to $surface.
+  .listfeaturedtag {
+    background-color: $surface;
+    border-color: $rule;
+  }
+
+  // Ties .card-text above on specificity (0,2,1) and currently only wins
+  // because main.css is linked after screen.css. Naming the same selectors
+  // makes the excerpt colour independent of link order.
+  .listfeaturedtag h4.card-text,
+  .listrecent h4.card-text {
+    color: $text-muted;
+  }
+
+  // Card footer meta. The "Read Story" bookmark is not listed here on purpose:
+  // .svgIcon-use now fills with currentColor, and the blanket `a` rule above
+  // already paints it $link with !important, which is how every other link in a
+  // card footer renders.
+  span.post-date,
+  span.post-read,
+  .post-top-meta span {
+    color: $text-muted;
+  }
+
+  // The rule above each card grid — "Featured", "All Stories", "Posts tagged X".
+  .section-title h2 {
+    border-bottom-color: $rule;
+  }
+
+  .section-title span {
+    border-bottom-color: $text-muted;
+  }
+
+  // rgba(0,0,0,.05) on #0d1117 is no pill at all, and the .6 black label on top
+  // of it is unreadable. Covers .after-post-tags too — same ul.tags markup.
+  ul.tags li a {
+    background: #21262d;
+    color: $text-muted;
+
+    &:hover {
+      background: #30363d;
+      color: $text;
+    }
+  }
+
+  // Dormant — post.html renders no related-posts block today — but a near-white
+  // slab the moment one comes back.
+  .graybg {
+    background-color: $surface;
+  }
+
+  .listrelated .card {
+    box-shadow: 0 1px 7px rgba(0, 0, 0, 0.4);
+  }
+
   .site-footer.bg-dark {
     background-color: #010409 !important;
     border-top: 1px solid $rule;
   }
 
-  hr,
-  .sep,
-  .after-post-tags .tags li a {
+  hr {
     border-color: $rule;
+  }
+
+  // .sep draws its rule with `background: #999`, not a border, so the
+  // border-color it used to share with `hr` never applied to it. The tag pills
+  // that shared that rule have no border either — they are handled by the
+  // `ul.tags li a` background above.
+  .sep {
+    background-color: $rule;
   }
 
   blockquote {
@@ -174,7 +243,16 @@ $link-hover: #a5d6ff;
 
   // The rail and the active marker take $rule (#eaeaea) and $accent (#0a2b46)
   // from _components.scss. Unoverridden that is a near-white 2px line and an
-  // almost-invisible navy marker against #0d1117.
+  // almost-invisible navy marker against #0d1117. Same for the divider that
+  // separates the TOC from the share block above it, and the share icon rings.
+  .toc {
+    border-top-color: $rule;
+  }
+
+  .share ul li i.fab {
+    border-color: $rule;
+  }
+
   .toc-list {
     border-left-color: $rule;
   }


### PR DESCRIPTION
## What changed

Three commits: the `data-theme` / `data-bs-theme` conflict on `<html>`, the Disqus → giscus migration, and — new here — separating the two blocks in the post left rail and finishing the dark layer over the vendored `screen.css`.

## Why

**The rail.** `.share` and the table of contents shared one scrollport: `.post-rail` capped itself at the viewport with `overflow-y: auto`, so on a long post scrolling the TOC dragged the whole share block out of view. That `overflow-y` also computed `overflow-x` to `auto` (CSS Overflow 3 §3.1), clipping a 148px column horizontally.

The rail no longer scrolls. It is a sticky flex column that gives `.share` its natural height and hands the remainder to the TOC, which splits again into a pinned heading and a scrolling `.toc-list`. A divider separates them — 1.5rem of margin between a centred block and a left-aligned one read as one blob.

Two adjacent holes closed while in there:

- The rail bounds are now `$rail-bp` / `$rail-bp-max`. `min-width: 1024px` against `max-width: 1023px` left the open interval between them matching **neither**, which browser zoom and 125%/150% display scaling land in routinely — the TOC appeared while the rail was un-pinned.
- Both stylesheets are cache-busted. `main.css` overrides `screen.css`, so a visitor holding one from cache and one fresh got `.share` back at `screen.css`'s `position: fixed`, on top of the TOC — the exact overlap the rail rules exist to prevent.

**Dark mode.** `screen.css` hardcodes colours that `_dark.scss` had not reached. The one that actually disappears: the "Read Story" bookmark in *every* post card is an inline `<svg>` with no `fill` attribute and no rule setting one, so it painted UA-default black on a `#161b22` footer. Also `.listfeaturedtag`'s border and missing background, the `.section-title` dividers above each card grid, and the `ul.tags` pills (`rgba(0,0,0,.05)` on `#0d1117` is not a pill). Card excerpts were relying on a specificity *tie* broken only by link order; the full selectors are now named.

Two existing overrides turned out to be no-ops and are repaired: `.sep` draws its line with `background`, not a border, and the tag pills that shared that `border-color` rule have no border either.

### Two deliberate light-mode changes

- The bookmark icon goes black → 44% black, matching the date beside it (`.svgIcon-use { fill: currentColor }` fixes both themes at once).
- The share icons regain their 30px rings. `screen.css` targets `.share ul li i.fa`, but the markup emits `i.fab` — that stopped matching when Font Awesome 6 made `fab` its own class rather than a modifier on `fa`.

`assets/css/screen.css` is not modified, per the repo convention.

## Checklist

- [x] `bundle exec jekyll build` succeeds locally
- [x] No post URLs changed
- [ ] Checked on mobile and desktop widths if this touches layout

On the last box — this **does** touch layout, and it was verified by reading the compiled `main.css` in both dark branches (the `[data-theme]` attribute rule and the `prefers-color-scheme` fallback) rather than in a browser, since none was available. Worth an eyeball at ≥1024px on `/2024/09/09/longlingua/` — 27 headings, the worst case in the repo — plus one narrow width to confirm the TOC hides and the article stacks first.

CI's html-proofer cannot run on Windows (no libcurl), so the one thing this change could break there was checked directly: `Addressable::URI#path`, which html-proofer uses to resolve internal links, strips the `?v=` query and both stylesheets still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
