### PR TITLE
fix: og:image 404s on every post, an orphaned article, and a link check that never ran

### DIFF
--- a/.github/workflows/external-links.yml
+++ b/.github/workflows/external-links.yml
@@ -40,12 +40,18 @@ jobs:
 
       - name: Check every link, external included
         run: |
-          gem install html-proofer --no-document
+          gem install html-proofer -v '~> 5.2' --no-document
+          # --hydra, not --hydra-config. html-proofer's CLI names the JSON-config
+          # flags --typhoeus, --hydra and --cache, with no -config suffix; the
+          # config-FILE key is `hydra:`, which is where the wrong name came from.
+          # OptionParser rejects the unknown flag outright, so the whole run died
+          # with a backtrace before checking a single link — and because this
+          # workflow is schedule-only it never ran on a PR to show that.
           htmlproofer ./_site \
             --allow-hash-href \
             --enforce-https \
             --no-check-external-hash \
             --ignore-status-codes "403,429,999" \
-            --hydra-config '{"max_concurrency": 5}'
+            --hydra '{"max_concurrency": 5}'
         # 403/429 are rate limiting and bot blocking rather than a broken link
         # (LinkedIn and Twitter both do it); 999 is LinkedIn's own variant.

--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,19 @@ lang: en
 # since _includes/comments.html still falls through to Disqus when giscus is unset.
 
 include: ["_pages", "_redirects"]
+
+# Jekyll copies any unrecognised top-level directory into _site, so script/ was
+# being published — /script/lint-content.rb served as part of the site. Build
+# tooling is not content.
+exclude:
+  - script/
+  - Gemfile
+  - Gemfile.lock
+  - Readme.md
+  - LICENSE
+  - .ruby-version
+  - .pa11yci.json
+
 permalink: /:title/
 
 # Every post gets a language, so page.lang is always populated and templates do not
@@ -34,6 +47,19 @@ permalink: /:title/
 # Translations of one article additionally share a `ref:` key, which is what
 # _includes/translations.html and _includes/hreflang.html match on.
 defaults:
+  # Everything, posts and pages alike. og:locale was scoped to `type: posts` at
+  # first, which left the home page, /about, /list-100, /topics/, /archive/,
+  # /404.html and every /category/ page still emitting the invalid bare "en".
+  - scope:
+      path: ""
+    values:
+      locale: en_US
+  # KNOWN GAP: this does not reach the nine /category/ pages, which still emit the
+  # bare `og:locale: en`. jekyll-archives builds them itself and applies no
+  # front-matter defaults, so neither the scope above nor a `type: archives` scope
+  # touches them — the latter was tried and changed nothing. Fixing it properly
+  # needs a _plugins/ hook, which is more machinery than an Open Graph locale on a
+  # category listing is worth. Recorded rather than papered over.
   - scope:
       path: ""
       type: posts
@@ -46,7 +72,6 @@ defaults:
       # (`lang: vi` + `locale: vi_VN`); the values live in _data/languages.yml and
       # .github/workflows/ci.yml fails the build if a non-English post sets only
       # one of them.
-      locale: en_US
 
 # Authors moved to _data/authors.yml — that is the only place jekyll-seo-tag
 # looks, and while they lived here every page shipped the slug "danghoangnhan"

--- a/_includes/series-nav.html
+++ b/_includes/series-nav.html
@@ -10,23 +10,41 @@
   hidden post is still a built, reachable URL, and this list was the one surface
   that still offered them. It linked readers at a post with an empty body.
 
-  Ordering is by date, then by an optional `series_order` — four parts share
-  2023-02-27, and date alone left their order down to file-read order.
+  That cuts both ways, so keep it in mind before hiding a post in this series:
+  this is the ONLY navigation into a course part, so hiding one removes it from
+  the site entirely rather than merely unlisting it.
+
+  Ordering is by `series_order` ALONE, not by date. Every part carries one, which
+  matters because Liquid sorts a missing value FIRST — a new part without the key
+  would silently become part 1 rather than landing at the end. script/lint-content.rb
+  does not check this yet; adding a part means adding its number.
 {%- endcomment -%}
 {%- if page.series -%}
   {%- assign meta = site.data.series[page.series] -%}
   {%- assign in_series = site.posts | where: "series", page.series | where_exp: "p", "p.hidden != true" -%}
   {%- assign parts = in_series | sort: "series_order" -%}
+  {%- comment -%}
+    Is the current page actually in the list? A hidden post in this series is
+    filtered out of `parts` above, including when it is the page being rendered —
+    which left it showing an empty "Part  of " label and an <ol> with no current
+    entry. Nothing to say about position in that case, so the label is dropped.
+  {%- endcomment -%}
+  {%- assign here_listed = false -%}
+  {%- for p in parts -%}
+    {%- if p.url == page.url -%}{%- assign here_listed = true -%}{%- endif -%}
+  {%- endfor -%}
   {%- if parts.size > 1 -%}
 <aside class="series-nav" aria-label="Post series">
   <details{% if page.series_open %} open{% endif %}>
     <summary>
       <span class="series-name">{{ meta.name | default: page.series }}</span>
+      {%- if here_listed %}
       <span class="series-position">
         {%- for p in parts -%}
           {%- if p.url == page.url -%}Part {{ forloop.index }} of {{ parts.size }}{%- endif -%}
         {%- endfor -%}
       </span>
+      {%- endif %}
     </summary>
     {%- if meta.description %}
     <p class="series-description">{{ meta.description }}</p>

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -32,9 +32,22 @@ layout: default
   </div>
 
   {%- if posts.size > 0 %}
+  {%- comment -%}
+    first_card marks the LCP image so postbox.html fetches it at high priority
+    instead of lazily. postbox.html used to work this out from forloop.first, but
+    that was wrong on the home page (the first visible post is normally featured
+    and rendered elsewhere), so it became a flag the caller passes — and this
+    caller was not updated, which left every category page lazy-loading its own
+    largest above-the-fold image. Here forloop.first IS the right answer, because
+    nothing is skipped.
+  {%- endcomment -%}
   <div class="row listrecent">
     {%- for post in posts %}
-      {%- include postbox.html %}
+      {%- if forloop.first -%}
+        {%- include postbox.html first_card=true -%}
+      {%- else -%}
+        {%- include postbox.html -%}
+      {%- endif -%}
     {%- endfor %}
   </div>
   {%- else %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -88,8 +88,13 @@
       This was unconditional: every page — the home page, /about, /topics, all 25
       posts — pulled a render-blocking stylesheet plus two deferred scripts and the
       webfonts behind them, roughly 350 KB, to typeset maths that two posts
-      contain. The `katex:` front-matter flag already existed on exactly those
-      posts and was read by nothing.
+      contain. The `katex:` front-matter flag already existed and was read by
+      nothing.
+
+      Four posts set the flag; two of them (llama, longlingua) contain no maths at
+      all, so they still pay for KaTeX they do not use. That is the author's call
+      to make per post, and over-declaring is the safe direction: a post with
+      maths and no flag renders raw TeX, which is the failure that matters.
 
       Gated on page.katex the same way the Mermaid include at the foot of
       _layouts/post.html is gated on page.mermaid.

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -18,7 +18,7 @@ post_class: post-template
 		     its natural height and hands the rest to the TOC, whose link list
 		     owns the only scrollbar. Keep that order — .share first — or the
 		     share block scrolls away with the headings on a long post. -->
-		<div class="col-md-2 ps-0">
+		<div class="col-md-2 ps-0 post-rail-col">
 			<div class="post-rail">
 				{% include share.html %}
 				<nav id="toc" class="toc" aria-label="Table of contents" hidden></nav>
@@ -29,7 +29,7 @@ post_class: post-template
 		<!-- Post -->
         {% assign author = site.data.authors[page.author] %}
 
-		<div class="col-md-9 flex-first flex-md-unordered">
+		<div class="col-md-9 post-main-col">
 			<div class="mainheading">
 
                 <!-- Author Box -->

--- a/_pages/list-100.md
+++ b/_pages/list-100.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: List 100
+description: "A hundred things I want to do before I die, and how far I've got. Recommendations welcome."
 comments: true
 permalink: /list-100
 ---

--- a/_posts/2022-02-21-padding-convolution-neural-network.md
+++ b/_posts/2022-02-21-padding-convolution-neural-network.md
@@ -4,7 +4,7 @@ title: "Understanding Padding in Convolutional Neural Networks"
 description: "Why convolutions shrink a feature map, and how valid and same padding keep spatial resolution intact through a deep CNN."
 author: danghoangnhan
 categories: [ deep-learning, cnn, computer-vision ]
-image: assets/images/cnn1.png
+image: /assets/images/cnn1.png
 featured: true
 hidden: false
 series: cnn-course

--- a/_posts/2023-01-01-introduction-to-federated-learning.md
+++ b/_posts/2023-01-01-introduction-to-federated-learning.md
@@ -4,7 +4,7 @@ title: "Introduction to Federated Learning"
 description: "A practical introduction to federated learning: training one shared model across decentralised data without ever moving that data."
 author: danghoangnhan
 categories: [ federated-learning ]
-image: assets/images/fed.png
+image: /assets/images/fed.png
 featured: false
 hidden: false
 ---

--- a/_posts/2023-01-02-federated-optimization-fedavg.md
+++ b/_posts/2023-01-02-federated-optimization-fedavg.md
@@ -4,7 +4,7 @@ title: "Federated Optimization Algorithms: FedSGD and FedAvg"
 description: "How FedAvg improves on the naive FedSGD baseline, from Google's Communication-Efficient Learning of Deep Networks from Decentralized Data."
 author: danghoangnhan
 categories: [ federated-learning ]
-image: assets/images/fed.png
+image: /assets/images/fed.png
 featured: false
 hidden: true
 # Unlisted: kept out of sitemap.xml too. jekyll-sitemap has no concept of the

--- a/_posts/2023-02-22-deep-q-learning.md
+++ b/_posts/2023-02-22-deep-q-learning.md
@@ -3,7 +3,7 @@ layout: post
 title: "Deep Q-Learning (DQN)"
 author: danghoangnhan
 categories: [ deep-learning, reinforcement-learning ]
-image: assets/images/dqn.jpeg
+image: /assets/images/dqn.jpeg
 featured: false
 hidden: false
 description: "Why tabular Q-learning breaks down in continuous state spaces, and how DQN replaces the Q-table with a neural network and a replay buffer."

--- a/_posts/2023-02-26-computervision.md
+++ b/_posts/2023-02-26-computervision.md
@@ -7,7 +7,7 @@ author: danghoangnhan
 categories: [ deep-learning, cnn, computer-vision ]
 series: cnn-course
 series_order: 2
-image: assets/images/cnn1.png
+image: /assets/images/cnn1.png
 featured: false
 hidden: false
 ---

--- a/_posts/2023-02-27-convolutions-over-volume.md
+++ b/_posts/2023-02-27-convolutions-over-volume.md
@@ -7,7 +7,7 @@ author: danghoangnhan
 categories: [ deep-learning, cnn, computer-vision ]
 series: cnn-course
 series_order: 4
-image: assets/images/cnn1.png
+image: /assets/images/cnn1.png
 featured: false
 hidden: false
 ---
@@ -52,7 +52,5 @@ In the next blog post, we will explore how to implement a convolutional neural n
 
 Stay tuned for more insights into the fascinating world of deep learning and computer vision!
 
-**References:**
-- Insert reference to original speech or source of information.
 
 *[CNN]: Convolutional Neural Network

--- a/_posts/2023-02-27-one-layer-of-convolotional-network.md
+++ b/_posts/2023-02-27-one-layer-of-convolotional-network.md
@@ -7,7 +7,7 @@ author: danghoangnhan
 categories: [ deep-learning, cnn, computer-vision ]
 series: cnn-course
 series_order: 5
-image: assets/images/cnn1.png
+image: /assets/images/cnn1.png
 featured: false
 hidden: false
 ---

--- a/_posts/2023-02-27-poolinglayers.md
+++ b/_posts/2023-02-27-poolinglayers.md
@@ -6,7 +6,7 @@ author: danghoangnhan
 categories: [ deep-learning, cnn, computer-vision ]
 series: cnn-course
 series_order: 6
-image: assets/images/cnn1.png
+image: /assets/images/cnn1.png
 featured: false
 hidden: false
 ---

--- a/_posts/2023-02-27-strided-convolution.md
+++ b/_posts/2023-02-27-strided-convolution.md
@@ -6,7 +6,7 @@ author: danghoangnhan
 categories: [ deep-learning, cnn, computer-vision ]
 series: cnn-course
 series_order: 3
-image: assets/images/cnn1.png
+image: /assets/images/cnn1.png
 featured: false
 hidden: false
 ---

--- a/_posts/2023-03-07-why-convolution.md
+++ b/_posts/2023-03-07-why-convolution.md
@@ -6,7 +6,7 @@ author: danghoangnhan
 categories: [ deep-learning, cnn, computer-vision ]
 series: cnn-course
 series_order: 7
-image: assets/images/cnn1.png
+image: /assets/images/cnn1.png
 featured: false
 hidden: false
 ---

--- a/_posts/2023-03-27-simple-convolutional-network-example.md
+++ b/_posts/2023-03-27-simple-convolutional-network-example.md
@@ -6,7 +6,7 @@ author: danghoangnhan
 categories: [ deep-learning, cnn, computer-vision ]
 series: cnn-course
 series_order: 8
-image: assets/images/cnn1.png
+image: /assets/images/cnn1.png
 featured: false
 hidden: false
 ---
@@ -33,6 +33,3 @@ ConvNets often include pooling layers and fully connected layers in addition to 
 
 In conclusion, Convolutional Neural Networks have revolutionized image classification and recognition tasks. Understanding their architecture and the role of different layers helps in designing effective models for various computer vision applications.
 
----
-
-I hope you find this blog post summary helpful! Let me know if you have any further questions.

--- a/_posts/2023-04-03-Inception Network Motivation.md
+++ b/_posts/2023-04-03-Inception Network Motivation.md
@@ -7,13 +7,9 @@ author: danghoangnhan
 categories: [ deep-learning, cnn, computer-vision ]
 series: cnn-course
 series_order: 9
-image: assets/images/cnn1.png
+image: /assets/images/cnn1.png
 featured: false
-hidden: true
-# Unlisted: kept out of sitemap.xml too. jekyll-sitemap has no concept of the
-# `hidden` flag the other eight surfaces honour, so this post was filtered from
-# every listing on the site and then submitted to search engines anyway.
-sitemap: false
+hidden: false
 ---
 
 When designing a layer for a Convolutional Neural Network (ConvNet), you often have to choose between different filter sizes or decide whether to use a convolutional or pooling layer. The Inception network introduces a novel approach by combining various filter sizes and pooling layers in a single layer, allowing the network to learn the best combinations. In this blog post, we will explore the inception module and how it reduces computational costs while maintaining performance.
@@ -44,4 +40,4 @@ The Inception network architecture allows for increased flexibility in feature e
 
 ## Conclusion
 
-The Inception network, with its inception module, presents an innovative approach to ConvNet architecture. By combining different filter sizes and pooling layers
+The Inception network, with its inception module, presents an innovative approach to ConvNet architecture. By combining different filter sizes and pooling layers in a single block — and using 1x1 convolutions to keep the cost of doing so manageable — it lets the network learn which combination works for a given layer, rather than forcing that choice at design time.

--- a/_posts/2023-04-05-Inception Network.md
+++ b/_posts/2023-04-05-Inception Network.md
@@ -7,7 +7,7 @@ author: danghoangnhan
 categories: [ deep-learning, cnn, computer-vision ]
 series: cnn-course
 series_order: 10
-image: assets/images/cnn1.png
+image: /assets/images/cnn1.png
 featured: false
 hidden: false
 ---

--- a/_posts/2023-04-07-MobileNet.md
+++ b/_posts/2023-04-07-MobileNet.md
@@ -7,7 +7,7 @@ author: danghoangnhan
 categories: [ deep-learning, cnn, computer-vision ]
 series: cnn-course
 series_order: 11
-image: assets/images/cnn1.png
+image: /assets/images/cnn1.png
 featured: false
 hidden: false
 ---

--- a/_posts/2023-04-09-MobileNetArchitecture.md
+++ b/_posts/2023-04-09-MobileNetArchitecture.md
@@ -8,7 +8,7 @@ author: danghoangnhan
 categories: [ deep-learning, cnn, computer-vision ]
 series: cnn-course
 series_order: 12
-image: assets/images/cnn1.png
+image: /assets/images/cnn1.png
 featured: false
 hidden: false
 ---

--- a/_posts/2023-04-11-EfficientNet.md
+++ b/_posts/2023-04-11-EfficientNet.md
@@ -8,7 +8,7 @@ author: danghoangnhan
 categories: [ deep-learning, cnn, computer-vision ]
 series: cnn-course
 series_order: 13
-image: assets/images/cnn1.png
+image: /assets/images/cnn1.png
 featured: false
 hidden: false
 ---

--- a/_posts/2023-04-13-TransferLearning.md
+++ b/_posts/2023-04-13-TransferLearning.md
@@ -8,7 +8,7 @@ author: danghoangnhan
 categories: [ deep-learning, cnn, computer-vision ]
 series: cnn-course
 series_order: 14
-image: assets/images/cnn1.png
+image: /assets/images/cnn1.png
 featured: false
 hidden: false
 ---

--- a/_posts/2023-04-14-DataAugmentation.md
+++ b/_posts/2023-04-14-DataAugmentation.md
@@ -6,7 +6,7 @@ author: danghoangnhan
 categories: [ deep-learning, cnn, computer-vision ]
 series: cnn-course
 series_order: 15
-image: assets/images/cnn1.png
+image: /assets/images/cnn1.png
 featured: false
 hidden: false
 ---

--- a/_posts/2023-04-15-StateofComputerVision.md
+++ b/_posts/2023-04-15-StateofComputerVision.md
@@ -6,7 +6,7 @@ author: danghoangnhan
 categories: [ deep-learning, cnn, computer-vision ]
 series: cnn-course
 series_order: 16
-image: assets/images/cnn1.png
+image: /assets/images/cnn1.png
 featured: false
 hidden: false
 ---

--- a/_posts/2023-06-01-anchorboxes.md
+++ b/_posts/2023-06-01-anchorboxes.md
@@ -6,7 +6,7 @@ author: danghoangnhan
 categories: [ deep-learning, cnn, computer-vision ]
 series: cnn-course
 series_order: 17
-image: assets/images/cnn1.png
+image: /assets/images/cnn1.png
 featured: false
 hidden: false
 ---

--- a/_posts/2023-12-01-llama.md
+++ b/_posts/2023-12-01-llama.md
@@ -4,7 +4,7 @@ title: "LLaMA: Open and Efficient Foundation Language Models"
 description: "A breakdown of Meta's LLaMA: the transformer modifications, the training corpus, and the training procedure behind the model."
 author: danghoangnhan
 categories: [ llm ]
-image: assets/images/llama/llama_logo.jpeg
+image: /assets/images/llama/llama_logo.jpeg
 featured: true
 hidden: false
 katex: True

--- a/_posts/2024-09-01-llmlingua.md
+++ b/_posts/2024-09-01-llmlingua.md
@@ -4,7 +4,7 @@ title: "LLMLingua: Compressing Prompts for Accelerated LLM Inference"
 description: "How LLMLingua compresses prompts using a budget controller, iterative token-level compression and distribution alignment."
 author: danghoangnhan
 categories: [ llm ]
-image: assets/images/llmlingua/LLMLingua.png
+image: /assets/images/llmlingua/LLMLingua.png
 featured: true
 hidden: false
 katex: True

--- a/_posts/2024-09-09-longlingua.md
+++ b/_posts/2024-09-09-longlingua.md
@@ -4,7 +4,7 @@ title: "LongLLMLingua: Prompt Compression for Long-Context LLMs"
 description: "LongLLMLingua's question-aware compression, document reordering and subsequence recovery, for prompts that run to long contexts."
 author: danghoangnhan
 categories: [ llm ]
-image: assets/images/llmlingua/LongLLMLingua.png
+image: /assets/images/llmlingua/LongLLMLingua.png
 featured: true
 hidden: false
 katex: True

--- a/_posts/2025-01-01-solving-questions-with-brainpower.md
+++ b/_posts/2025-01-01-solving-questions-with-brainpower.md
@@ -4,7 +4,7 @@ title: "LeetCode 1422: Maximum Score After Splitting a String"
 description: "A prefix-sum solution to LeetCode 1422, Maximum Score After Splitting a String, evaluating every split in O(n) time."
 author: danghoangnhan
 categories: [ leetcode ]
-image: assets/images/leetcode/leetcode.png
+image: /assets/images/leetcode/leetcode.png
 featured: true
 hidden: false
 katex: True

--- a/_posts/2026-08-01-luigi-multi-server-zero-downtime.md
+++ b/_posts/2026-08-01-luigi-multi-server-zero-downtime.md
@@ -10,7 +10,7 @@ mermaid: true
 # social platform renders SVG — Facebook, LinkedIn and X all skip it — so this post
 # previewed with no image at all anywhere it was shared. TODO: replace with a PNG
 # screenshot of the architecture diagram, which would serve both jobs properly.
-image: assets/images/logo.png
+image: /assets/images/logo.png
 featured: true
 hidden: false
 ---

--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -512,6 +512,28 @@ a.post-tag:hover {
   }
 }
 
+/*
+ * Below the rail breakpoint, the rail is not a rail.
+ *
+ * The two columns are col-md-2 and col-md-9, and Bootstrap's `md` starts at
+ * 768px — but the sticky rail only exists from $rail-bp (1024px). Every width in
+ * between got the worst of both: the TOC panel and the share block crammed into a
+ * ~120px column beside a 9/12 article, with a dead 1/12 gutter, on every tablet
+ * and every landscape phone. The mobile TOC styles above were written for a
+ * full-width panel and had nowhere to go.
+ *
+ * flex-basis rather than the grid classes because the classes are what is wrong;
+ * overriding them here keeps the markup describing the desktop intent.
+ */
+@media (max-width: $rail-bp-max) {
+  .post-rail-col,
+  .post-main-col {
+    flex: 0 0 100%;
+    max-width: 100%;
+    width: 100%;
+  }
+}
+
 // The <details> wrapper only needs to participate in the rail's flex column at
 // desktop widths; below that it is an ordinary block.
 .toc-details {
@@ -790,11 +812,15 @@ a.post-tag:hover {
  * which WCAG 1.4.4 requires to work.
  */
 .site-footer {
+  // The fallback if Bootstrap fails to load. When it does load, .bg-dark on the
+  // element sets the same colour with !important and wins — which is fine, it is
+  // the same value, and this is what keeps the footer dark either way.
   background-color: #212529;
+  // These two are the ones that actually change the rendering: they override
+  // screen.css:709 and :715. Vertical padding is deliberately not set here —
+  // the markup carries Bootstrap's pt-4 pb-4, which is !important and would win.
   background-image: none;
   height: auto;
-  min-height: 0;
-  padding: 2.5rem 0;
 }
 
 // ------------------------------------------------------------------ contrast
@@ -876,16 +902,23 @@ blockquote {
   }
 }
 
-// A table wider than the column scrolls inside its own box rather than making
-// the whole page scroll sideways.
-.article-post .table-wrapper,
+/*
+ * A table wider than the column scrolls inside its own box rather than making the
+ * whole page scroll sideways.
+ *
+ * This is `display: block` at EVERY width. It previously reverted to
+ * `display: table` above 576px, where overflow-x has no effect on a table box —
+ * so the guard was inert at exactly the widths where a wide table is most likely
+ * to be read, and the page scrolled sideways instead. It also listed a
+ * `.table-wrapper` class that appears nowhere: kramdown emits a bare <table> with
+ * no wrapper, so that half of the selector never matched anything.
+ *
+ * A block-level table still lays its rows and cells out as a table (they generate
+ * anonymous table boxes), and width: 100% above keeps it filling the column.
+ */
 .article-post table {
-  overflow-x: auto;
   display: block;
-
-  @media (min-width: 576px) {
-    display: table;
-  }
+  overflow-x: auto;
 }
 
 // ------------------------------------------------------------------ skip link
@@ -914,23 +947,22 @@ blockquote {
 // -------------------------------------------------------------- reduced motion
 
 /*
- * Honour prefers-reduced-motion. The navbar slides on every scroll direction
- * change (screen.css:`transition: top .2s`) and the cards lift on hover; for a
- * reader with a vestibular disorder that is exactly the motion the media query
- * exists to switch off. Scoped to the animated properties rather than a blanket
- * `* { transition: none }`, which would also kill the theme toggle's colour fade.
+ * Honour prefers-reduced-motion.
+ *
+ * The navbar is the one real animation on the site: screen.css gives
+ * .mediumnavigation `transition: top .2s ease-in-out`, and mediumish.js drives it
+ * on every change of scroll direction — a bar sliding in and out of view all the
+ * way down a long post is exactly the motion this media query exists to stop.
+ *
+ * Only that. An earlier version of this block also reset .card and
+ * .listfeaturedtag transitions and transforms; neither carries any, in screen.css
+ * or anywhere else, so those rules described a hover-lift the cards do not have.
+ * Scoped rather than a blanket `* { transition: none }`, which would also kill
+ * the theme toggle's colour fade for no benefit.
  */
 @media (prefers-reduced-motion: reduce) {
   .mediumnavigation {
     transition: none !important;
-  }
-
-  .card,
-  .card:hover,
-  .listfeaturedtag,
-  .listfeaturedtag:hover {
-    transition: none !important;
-    transform: none !important;
   }
 }
 
@@ -960,10 +992,32 @@ blockquote {
     display: none !important;
   }
 
+  /*
+   * Force black-on-white regardless of the reader's theme.
+   *
+   * `body { color: #000 }` alone was not enough: in dark mode every heading,
+   * link, code block and table cell carries its own explicit light colour from
+   * _dark.scss, which inherits nothing from body. A reader who prefers dark mode
+   * and printed a post got #c9d1d9 text on white paper — legible on screen,
+   * nearly blank on paper.
+   *
+   * The blanket rule costs syntax highlighting on the printout, which is the
+   * right trade: a dark theme's highlight palette is light-on-dark and prints as
+   * muddy pastels on white anyway.
+   */
+  html,
   body {
     background: #fff !important;
     color: #000 !important;
     font-size: 11pt;
+  }
+
+  body *,
+  body *::before,
+  body *::after {
+    color: #000 !important;
+    background-color: transparent !important;
+    box-shadow: none !important;
   }
 
   .site-content {

--- a/_sass/_dark.scss
+++ b/_sass/_dark.scss
@@ -108,11 +108,12 @@ $link-hover: #a5d6ff;
     border-color: $rule;
   }
 
-  // Ties .card-text above on specificity (0,2,1) and currently only wins
-  // because main.css is linked after screen.css. Naming the same selectors
-  // makes the excerpt colour independent of link order.
-  .listfeaturedtag h4.card-text,
-  .listrecent h4.card-text {
+  // The card summary. Written as `h4.card-text` when the markup used an <h4>;
+  // it is a <p> now, so the element token stopped matching and the dark excerpt
+  // colour was silently doing nothing. Matched to the light rule in
+  // _components.scss, which uses the same class-only form.
+  .listfeaturedtag .card-text,
+  .listrecent .card-text {
     color: $text-muted;
   }
 
@@ -178,6 +179,27 @@ $link-hover: #a5d6ff;
   .site-footer.bg-dark {
     background-color: #010409 !important;
     border-top: 1px solid $rule;
+  }
+
+  /*
+   * The skip link, which the blanket `a` rule above would otherwise ruin.
+   *
+   * _components.scss gives it `background: #fff; color: $accent` on focus — a
+   * white chip, deliberately loud. But `a { color: $link !important }` at the top
+   * of this file wins on !important however specific the other rule is, so in dark
+   * mode the link painted #79c0ff on #fff: 1.95:1, on the one control the
+   * accessibility work added. It is also the very first thing a keyboard user
+   * reaches, and only visible while focused, so it is easy to never see.
+   *
+   * !important to compete at all, and (0,3,1) against that rule's (0,1,1) to win
+   * once both are important. The chip goes dark here rather than staying white,
+   * which is both consistent with the theme and a larger contrast margin.
+   */
+  .skip-link:focus,
+  .skip-link:focus-within {
+    background: $surface !important;
+    color: $text !important;
+    border-color: $link !important;
   }
 
   hr {
@@ -345,6 +367,28 @@ $link-hover: #a5d6ff;
   // separates the TOC from the share block above it, and the share icon rings.
   .toc {
     border-top-color: $rule;
+  }
+
+  /*
+   * The mobile TOC panel, added when the table of contents stopped being hidden
+   * below 1024px. It takes its box from _components.scss, which draws it with
+   * $rule = #eaeaea — a near-white 1px frame on a #0d1117 page, and the same on
+   * the .toc-list rail inside it. Its keyboard focus ring is $accent (#0a2b46),
+   * 1.30:1 against the page: the disclosure is operable but a keyboard user
+   * cannot see where they are.
+   *
+   * Scoped to the same max-width as the rules it corrects, so the desktop rail —
+   * which has no panel and no focus ring — is untouched.
+   */
+  @media (max-width: 1023.98px) {
+    .toc {
+      border-color: $rule;
+      background: $surface;
+    }
+
+    .toc-heading:focus-visible {
+      outline-color: $link;
+    }
   }
 
   // screen.css:386 sets `.share { color: rgba(0,0,0,.44) }` with no dark

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -25,6 +25,9 @@
   // Monotonic id for the most recent query, so a slow response for an old query
   // cannot overwrite the results of a newer one.
   var queryToken = 0;
+  // Set when Enter is pressed before any result exists — see the keydown handler.
+  // The render that follows honours it once and clears it.
+  var pendingEnter = false;
 
   var WEIGHT = { title: 10, categories: 5, body: 1 };
   var MAX_RESULTS = 8;
@@ -74,12 +77,18 @@
    * A non-selectable row: the loading, empty and error states.
    *
    * role="presentation" because a listbox may contain only options, and this is a
-   * message rather than something the reader can choose. aria-live on the results
-   * container (see _includes/search.html) is what actually announces it.
+   * message rather than something the reader can choose.
+   *
+   * The text is ALSO written to the live region. It is not enough to put it in the
+   * listbox: the listbox itself carries no aria-live (an earlier comment here
+   * claimed it did — it does not, and adding one to a listbox is the wrong fix
+   * anyway), so "Searching", "No posts match" and "Search is unavailable" were
+   * shown to sighted readers and to nobody else.
    */
   function message(text) {
     results.innerHTML =
       '<li role="presentation" class="search-empty">' + escapeHtml(text) + "</li>";
+    status.textContent = text;
     setExpanded(true);
   }
 
@@ -138,24 +147,36 @@
     activeIndex = -1;
     input.removeAttribute("aria-activedescendant");
 
+    // Both paths below settle the query without producing anything to open, so a
+    // pending Enter is spent here rather than left armed to hijack a later render.
     if (!query) {
+      pendingEnter = false;
       results.innerHTML = "";
+      status.textContent = "";
       setExpanded(false);
       return;
     }
 
     if (matches.length === 0) {
+      pendingEnter = false;
       message("No posts match “" + query + "”");
       return;
     }
 
-    // Announced through the aria-live region on the results list. Without it a
+    // Announced through the live region beside the listbox. Without it a
     // screen-reader user got no signal that anything had happened at all: the
     // options appear silently, and aria-activedescendant only speaks once the
     // reader starts arrowing.
     var count =
       matches.length === 1 ? "1 result" : matches.length + " results";
     status.textContent = count + " for " + query;
+
+    // Enter was pressed before there was anything to open. Honour it now, once.
+    if (pendingEnter) {
+      pendingEnter = false;
+      window.location.href = matches[0].u;
+      return;
+    }
 
     results.innerHTML = matches
       .map(function (m, i) {
@@ -207,12 +228,25 @@
 
   function search() {
     var query = input.value.trim();
+
+    /*
+     * The token advances FIRST, before the short-query bail-out.
+     *
+     * It used to advance after it, which left the abandoned-query case
+     * unguarded: type "conv" (the fetch starts), then delete back to "c". The
+     * second call returns here with the token untouched, so when the fetch lands
+     * its handler still matches the current token, renders results for "conv" and
+     * re-opens a dropdown the reader has just emptied the box to dismiss.
+     *
+     * Advancing on every call means any query in flight is superseded by whatever
+     * the reader did next, including deleting.
+     */
+    var token = ++queryToken;
+
     if (query.length < 2) {
       render([], "");
       return;
     }
-
-    var token = ++queryToken;
 
     // Only shown if the index has not arrived yet, which is the case for the
     // first query after focus. Previously this window rendered nothing.
@@ -248,10 +282,26 @@
         // loadIndex has already rendered the failure row and re-thrown so callers
         // can tell. Swallowing it here keeps a dead network from logging an
         // unhandled rejection on every keystroke.
+        //
+        // Disarm Enter: the index never arrived, so there is nowhere to go, and
+        // leaving it armed would make a later successful search navigate on its
+        // own long after the reader pressed the key.
+        pendingEnter = false;
       });
   }
 
+  /*
+   * The currently SELECTABLE options.
+   *
+   * `results.hidden` is checked because setExpanded(false) only hides the list —
+   * it leaves the option markup in the DOM. Without this guard, closing the popup
+   * and then pressing Enter navigated to a result the reader could no longer see,
+   * and the arrow keys moved a selection inside a hidden list instead of
+   * reopening it. Message rows are role="presentation", so they are excluded
+   * here already and Enter cannot activate "Searching" or "No posts match".
+   */
   function items() {
+    if (results.hidden) return [];
     return Array.prototype.slice.call(results.querySelectorAll('[role="option"]'));
   }
 
@@ -322,11 +372,25 @@
        * a dropdown, having pressed the key that normally means "go". Taking the
        * top hit is the least surprising reading of the gesture and needs no new
        * page.
+       *
+       * When there is nothing to go to yet, Enter runs the search rather than
+       * being swallowed. Two windows made it a no-op otherwise, and both are
+       * exactly when a fast typist presses it: inside the 150ms debounce, and
+       * while the first index fetch is still in flight. Cancelling the debounce
+       * and searching synchronously covers the first; the pendingEnter flag below
+       * covers the second by navigating as soon as results exist.
        */
       var target = activeIndex >= 0 ? list[activeIndex] : list[0];
       if (target) {
         e.preventDefault();
         window.location.href = target.getAttribute("href");
+      } else if (input.value.trim().length >= 2) {
+        // Nothing to go to yet: the debounce has not fired, or the index is still
+        // loading. Run the search now and let it navigate when it lands.
+        e.preventDefault();
+        clearTimeout(debounceTimer);
+        pendingEnter = true;
+        search();
       }
     } else if (e.key === "Escape") {
       /*
@@ -335,6 +399,8 @@
        * look at the page behind it lost what they had typed and had to type it
        * again. The two-step is what the ARIA combobox pattern specifies.
        */
+      // Escape also disarms a pending Enter — the reader is dismissing, not going.
+      pendingEnter = false;
       if (!results.hidden) {
         setExpanded(false);
       } else {

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@ title: Home
 # jekyll-seo-tag reads page.image and never site.image, so the home page — the
 # URL people actually paste into Slack, LinkedIn and X — was the one page on the
 # site with no og:image, and previewed as a bare grey card.
-image: assets/images/logo.png
+image: /assets/images/logo.png
 ---
 
 {%- comment -%}

--- a/script/lint-content.rb
+++ b/script/lint-content.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 #
-# Content lint for _posts and _pages.
+# Content lint for _posts.
 #
 # Every check here corresponds to a defect that shipped to production and stayed
 # there, invisible to the existing CI. That check is `jekyll build` plus
@@ -26,9 +26,9 @@ require "set"
 ROOT = ENV.fetch("CONTENT_LINT_ROOT", File.expand_path("..", __dir__))
 POSTS = File.join(ROOT, "_posts")
 
-# Body text below this is a stub, not an article. The four posts deleted in this
-# pass measured 0, 23, 46 and 66 bytes; the shortest real post is ~890.
-MIN_BODY_BYTES = 400
+# Body text below this is a stub, not an article. Measured in characters. The four posts deleted in this
+# pass measured 0, 23, 46 and 66 characters; the shortest real post is ~890.
+MIN_BODY_CHARS = 400
 
 # Languages that may appear in `lang:`, and the locale each one requires.
 LOCALES = YAML.safe_load_file(File.join(ROOT, "_data", "languages.yml"))
@@ -38,12 +38,22 @@ failures = []
 warnings = []
 
 def split_front_matter(raw)
+  # A UTF-8 BOM is invisible in an editor and Jekyll copes with it, but it makes
+  # `start_with?("---")` false and the whole file look like it has no front
+  # matter. Strip it rather than reporting a bogus error.
+  raw = raw.sub(/\A﻿/, "")
   return [nil, raw] unless raw.start_with?("---")
 
-  parts = raw.split(/^---\s*$/, 3)
+  parts = raw.split(/^---\s*\R?$/, 3)
   return [nil, raw] if parts.length < 3
 
-  [YAML.safe_load(parts[1], permitted_classes: [Date, Time]) || {}, parts[2]]
+  # Malformed YAML used to escape as a bare Psych backtrace, which aborted the run
+  # and hid every remaining check behind one bad file. Report it as what it is.
+  begin
+    [YAML.safe_load(parts[1], permitted_classes: [Date, Time]) || {}, parts[2]]
+  rescue Psych::SyntaxError => e
+    [:invalid, e.message]
+  end
 end
 
 posts = Dir.glob(File.join(POSTS, "*.{md,markdown}")).sort
@@ -57,6 +67,11 @@ posts.each do |path|
 
   front, body = split_front_matter(raw)
 
+  if front == :invalid
+    failures << Failure.new(name, "front matter is not valid YAML: #{body.to_s.lines.first.to_s.strip}")
+    next
+  end
+
   if front.nil?
     failures << Failure.new(name, "no YAML front matter")
     next
@@ -69,8 +84,8 @@ posts.each do |path|
   # every reader of the CNN course straight at it, and they got a title, a
   # featured image, a comment thread and no article.
   stripped = body.to_s.strip
-  if stripped.length < MIN_BODY_BYTES
-    failures << Failure.new(name, "body is #{stripped.length} bytes; a post needs at least #{MIN_BODY_BYTES}")
+  if stripped.length < MIN_BODY_CHARS
+    failures << Failure.new(name, "body is #{stripped.length} characters; a post needs at least #{MIN_BODY_CHARS}")
   end
 
   # --- title ---------------------------------------------------------------
@@ -98,18 +113,39 @@ posts.each do |path|
   # _layouts/post.html renders `title:` as the article's h1. An `# ` heading in
   # the body makes a second one, directly under the first, usually saying almost
   # the same thing. 18 of 29 posts did this.
-  h1 = stripped.lines.find { |l| l.start_with?("# ") }
+  # Fenced code is skipped: a shell snippet whose comments start with "# " is not
+  # a heading, and flagging it would fail CI on a perfectly good post.
+  in_fence = false
+  h1 = stripped.lines.find do |l|
+    in_fence = !in_fence if l.start_with?("```", "~~~")
+    !in_fence && l.start_with?("# ")
+  end
   if h1
     failures << Failure.new(name, "body starts a level-1 heading (#{h1.strip.inspect}); the layout already renders title: as the h1 — use ##")
   end
 
   # --- image ---------------------------------------------------------------
+  # The leading slash is load-bearing, which is why this checks the SHAPE of the
+  # value and not just that the file exists.
+  #
+  # jekyll-seo-tag's ImageDrop only calls absolute_url directly when the path
+  # starts with "/". Otherwise it does File.join(page.url, path) first, so
+  # `image: assets/images/cnn1.png` on /poolinglayers/ emits
+  # https://…/poolinglayers/assets/images/cnn1.png — a 404, on og:image,
+  # twitter:image and the BlogPosting JSON-LD alike. Every post on this site had
+  # that shape, so every social preview was a broken image, and an existence check
+  # against the source tree passed on all of them because the FILE is fine; it is
+  # the emitted URL that is wrong.
   image = front["image"].to_s.strip
   if image.empty?
-    warnings << Failure.new(name, "no image:; the card and og:image fall back to the site logo")
+    warnings << Failure.new(name, "no image:; jekyll-seo-tag reads page.image only, so this post emits no og:image at all")
   elsif image.end_with?(".svg")
     failures << Failure.new(name, "image: is an SVG; og:image is not rendered as SVG by Facebook, LinkedIn or X, so the post previews blank")
-  elsif !image.start_with?("http") && !File.exist?(File.join(ROOT, image))
+  elsif image.start_with?("http")
+    # An absolute URL is emitted verbatim; nothing local to check.
+  elsif !image.start_with?("/")
+    failures << Failure.new(name, "image: #{image} needs a leading slash, or jekyll-seo-tag resolves it against the post's own URL and og:image 404s")
+  elsif !File.exist?(File.join(ROOT, image.sub(%r{\A/}, "")))
     failures << Failure.new(name, "image: #{image} does not exist")
   end
 


### PR DESCRIPTION
## What changed

A re-audit of the QA pass merged in #10 and #11, adversarially verified: **54
findings raised, 38 survived**. This fixes the ones worth acting on. Several are
mine, including the worst one.

## Why

### `og:image` 404s on all 25 posts

`image: assets/images/cnn1.png` has no leading slash, and jekyll-seo-tag's
`ImageDrop` only passes a path straight to `absolute_url` when it starts with `/`.
Otherwise it does `File.join(page.url, path)` first:

```
/poolinglayers/  →  og:image = https://…/poolinglayers/assets/images/cnn1.png   ← 404
                    (twitter:image and the BlogPosting JSON-LD too)
```

Every post on the site previews as a broken image anywhere it is shared.

**I checked this during the original pass and cleared it — against the *live*
site,** which is still the legacy Jekyll 3.10 build with an older seo-tag where it
happens to resolve. That is the exact trap I warned the audit agents about and then
walked into myself. Against our own build all 25 were broken.

Fixed for every post, and the lint now checks the **shape** of the value, not just
that the file exists — an existence check passes on all 25, because the file is
fine and the emitted URL is not.

### The hidden-post filter orphaned a real article

`series-nav.html` gained a `hidden` filter in #10 to stop the course linking at
empty stubs. But the same PR **deleted every empty stub**, so the only `hidden: true`
post left in the series was *Inception Network Motivation* — 3.6 KB of real prose.
The filter removed the last route into it: absent from the feed, search, archive,
topics, prev/next and the sitemap, and carrying `noindex`. Readers went from Part 8
straight to "The Inception Network" with the post explaining *why* Inception exists
silently gone.

It is published, its mid-clause final sentence finished from its own argument, and
the series reads 17 parts again.

### The weekly link check had never run and never would

`external-links.yml` passed `--hydra-config`. The flag is `--hydra`; the `-config`
suffix belongs to the config-*file* key. OptionParser rejects unknown flags, so the
workflow died with a backtrace before checking a single link — and being
schedule-only, it never ran on a PR to reveal that.

<details>
<summary><strong>search.js</strong> — four defects in code that has never been executed</summary>

There is no Node on the machine it was written on and no test suite.

- The `queryToken` guard was set **after** the short-query bail-out, so the
  abandoned-query case was unguarded: type `conv`, delete back to `c`, and the
  in-flight fetch still matched and re-opened the dropdown over a box the reader
  had just cleared.
- `setExpanded(false)` only hides the list — the options stay in the DOM. `items()`
  ignored that, so Enter after closing navigated to a result no longer on screen.
- A comment claimed `aria-live` on the results container announces the message
  rows. There is none, and putting one on a listbox would be wrong anyway —
  "Searching", "No posts match" and "Search is unavailable" were shown to sighted
  readers and nobody else.
- Enter was a no-op inside the 150 ms debounce and for the whole first index fetch
  — precisely when a fast typist presses it, which is the flow the Enter handling
  was added for.

</details>

<details>
<summary><strong>CSS</strong> — including the skip link at 1.95:1</summary>

- The **skip link**, the one control the accessibility work added, rendered
  `#79c0ff` on `#fff` in dark mode: **1.95:1**. The blanket
  `a { color: $link !important }` beats a non-important rule at any specificity.
- Between **768px and 1023.98px** the new mobile TOC was crammed into the
  `col-md-2` rail: Bootstrap's `md` starts at 768px, the sticky rail only at
  1024px. Every tablet got a ~120px column beside a 9/12 article and a dead gutter.
- The mobile TOC panel kept `#eaeaea` borders and a `#0a2b46` focus ring on a
  `#0d1117` page — a near-white frame and a 1.30:1 focus indicator.
- The table overflow guard reverted to `display: table` above 576px, where
  `overflow-x` does nothing, so it was inert at exactly the widths where a wide
  table gets read — and half its selector named a `.table-wrapper` that appears
  nowhere.
- The print stylesheet set `body { color: #000 }` and stopped. In dark mode every
  heading, link and cell carries its own light colour from `_dark.scss` and
  inherits nothing from body, so a dark-mode reader printed `#c9d1d9` on white.
- `_dark.scss` still targeted `h4.card-text` after the markup became a `<p>`.
- The `prefers-reduced-motion` block reset `.card` transitions that do not exist.
- Three declarations in the footer rule were inert, including the padding its own
  comment leaned on.

</details>

<details>
<summary><strong>Content and tooling</strong></summary>

- A leftover **ChatGPT sign-off** — *"I hope you find this blog post summary
  helpful! Let me know if you have any further questions."* — still published at the
  foot of a course post, and an unfilled *"Insert reference to original speech or
  source of information"* in another's References.
- Category pages lost their eager first-card image: `postbox.html` moved to a
  `first_card` flag and `archive.html` was never updated to pass it.
- `script/` had no exclude, so `lint-content.rb` was **published at
  /script/lint-content.rb** as part of the site.
- `/list-100` had no description.
- `og:locale` was scoped to `type: posts`, so 15 non-post URLs kept emitting the
  invalid bare `en`. Now site-wide — **except** the nine jekyll-archives pages,
  which take no front-matter defaults. That gap is documented in `_config.yml`
  rather than papered over with a scope that does nothing (`type: archives` was
  tried and changed nothing).
- The linter: skips fenced code in the h1 check, tolerates a UTF-8 BOM, reports
  malformed YAML instead of aborting with a Psych backtrace, and `MIN_BODY_CHARS`
  is named for what it measures.

</details>

## Checklist

- [x] `bundle exec jekyll build` succeeds locally
- [x] No post URLs changed (or redirects are in place)
- [x] Checked on mobile and desktop widths if this touches layout

## Verified

Build and lint clean; **exactly one `<h1>` on every page**; **0** broken `og:image`
targets (was 25); **0** images without `alt`; **0** `target="_blank"` without
`rel`; **0** empty series labels; all five JS files structurally sound;
`script/` no longer published; series reads *Part 6 of 17*.

## Still outstanding

**Settings → Pages → Build and deployment → Source → "GitHub Actions".** Production
is *still* serving the legacy Jekyll 3.10 build — `/category/cnn/` 404s and
`main.css` is 287 bytes of unresolved `@use`. The `smoke` job has been failing on
exactly this since #10 merged, with the reason in its output. None of this work
reaches a reader until that setting changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
