### PR TITLE
feat: paginate the home page and the category archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,14 @@ jobs:
         # standalone page and a listing — because a template defect appears on
         # every page using it, and four is enough to see all four templates.
         #
+        # Two additions for pagination. /page2/ is not a fifth template but a second
+        # render state of the home one: paginator.page == 1 gates the Featured block
+        # and the de-duplication, so page 2 takes Liquid branches page 1 never runs,
+        # and it is the only page whose <h1> and active nav item depend on the
+        # is_home assign in _layouts/default.html holding. /category/cnn/ is here
+        # because _layouts/archive.html changed generator underneath it, from
+        # jekyll-archives to jekyll-paginate-v2's autopages.
+        #
         # This is the check that would have caught the missing landmarks, the
         # unnamed share buttons, the iframe with no title and the 3.23:1 body
         # text, none of which html-proofer can see.
@@ -74,9 +82,11 @@ jobs:
           npx http-server ./_site -p 4000 --silent &
           npx wait-on http://127.0.0.1:4000 --timeout 30000 || sleep 5
           URLS="http://127.0.0.1:4000/ \
+                http://127.0.0.1:4000/page2/ \
                 http://127.0.0.1:4000/poolinglayers/ \
                 http://127.0.0.1:4000/about \
-                http://127.0.0.1:4000/topics/"
+                http://127.0.0.1:4000/topics/ \
+                http://127.0.0.1:4000/category/cnn/"
 
           # The default reporter names the rule and the element but not the
           # measured value, so a contrast failure tells you which link is wrong and

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -92,10 +92,28 @@ jobs:
             *) echo "::error::Expected a Jekyll 4.x build. Production is not serving this workflow's artifact — check Settings > Pages > Source is 'GitHub Actions'."; exit 1 ;;
           esac
 
-          echo "--- category archives (jekyll-archives runs only on our own build)"
+          echo "--- category archives (jekyll-paginate-v2 autopages run only on our own build)"
           code=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/category/cnn/")
           echo "/category/cnn/ -> $code"
-          [ "$code" = "200" ] || { echo "::error::/category/cnn/ returned $code; jekyll-archives did not run."; exit 1; }
+          [ "$code" = "200" ] || { echo "::error::/category/cnn/ returned $code; the autopages generator did not run."; exit 1; }
+
+          # A 200 alone is not enough here. _layouts/archive.html reads the posts from
+          # paginator.posts, and if that ever goes back to the page.posts key that
+          # jekyll-archives used to set, every category still returns a valid 200 page
+          # — reading "Nothing published under this topic yet." So assert cards.
+          #
+          # Herestring rather than a pipe into grep, matching the stylesheet checks
+          # below: `grep -c` exits 1 on zero matches, and under `set -o pipefail` a
+          # pipe would fail the step before the assertion could report the count.
+          html=$(curl -fsSL "$BASE/category/cnn/")
+          cards=$(grep -c 'begin post' <<<"$html" || true)
+          echo "/category/cnn/ -> ${cards} cards"
+          [ "$cards" -ge 1 ] || { echo "::error::/category/cnn/ rendered ${cards} post cards; the archive layout is not seeing the paginator."; exit 1; }
+
+          echo "--- home pagination"
+          code=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/page2/")
+          echo "/page2/ -> $code"
+          [ "$code" = "200" ] || { echo "::error::/page2/ returned $code; pagination did not run."; exit 1; }
 
           echo "--- stylesheet compiled (Dart Sass @use resolved)"
           css=$(curl -fsSL "$BASE/assets/css/main.css")

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ source "https://rubygems.org"
 ruby file: ".ruby-version"
 
 # Jekyll proper, NOT the `github-pages` gem. That gem pins Jekyll 3.10 and a fixed
-# plugin allowlist which silently drops jekyll-archives. Building it ourselves via
-# GitHub Actions is what unlocks Jekyll 4 and arbitrary plugins.
+# plugin allowlist which silently drops jekyll-paginate-v2. Building it ourselves
+# via GitHub Actions is what unlocks Jekyll 4 and arbitrary plugins.
 gem "jekyll", "~> 4.4.1"
 
 group :jekyll_plugins do
@@ -15,8 +15,21 @@ group :jekyll_plugins do
   # every build log, for a gem that produced nothing.
   gem "jekyll-sitemap",  "~> 1.4.0"
   gem "jekyll-seo-tag",  "~> 2.9.0"
-  # Ignored by GitHub's legacy builder; starts working once we control the build.
-  gem "jekyll-archives", "~> 2.3.0"
+  # Replaces both jekyll-archives and the decommissioned jekyll-paginate v1.
+  #
+  # v1 filled paginator.posts from site.posts unconditionally with no filter
+  # hook, so `hidden: true` posts had to be skipped inside the Liquid loop and
+  # the pages came out ragged — which is why pagination was removed from this
+  # site entirely. v2 rejects hidden documents in the generator itself
+  # (paginationModel.rb: `docs.reject { |doc| doc['hidden'] }`), so the same
+  # markup now yields full pages and pagination is worth having again.
+  #
+  # Its autopages generator also emits the /category/<name>/ pages that
+  # jekyll-archives used to, with pagination built in, so the two would collide
+  # on the same permalinks. Only one of them can be installed.
+  #
+  # Ignored by GitHub's legacy builder; works because we control the build.
+  gem "jekyll-paginate-v2", "~> 3.0.0"
 end
 
 # Windows and JRuby ship no system tzdata.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,8 +43,8 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
-    jekyll-archives (2.3.0)
-      jekyll (>= 3.6, < 5.0)
+    jekyll-paginate-v2 (3.0.0)
+      jekyll (>= 3.0, < 5.0)
     jekyll-sass-converter (3.1.0)
       sass-embedded (~> 1.75)
     jekyll-seo-tag (2.9.0)
@@ -95,7 +95,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 4.4.1)
-  jekyll-archives (~> 2.3.0)
+  jekyll-paginate-v2 (~> 3.0.0)
   jekyll-seo-tag (~> 2.9.0)
   jekyll-sitemap (~> 1.4.0)
   tzinfo (>= 1, < 3)
@@ -120,7 +120,7 @@ CHECKSUMS
   http_parser.rb (0.8.1) sha256=9ae8df145b39aa5398b2f90090d651c67bd8e2ebfe4507c966579f641e11097a
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   jekyll (4.4.1) sha256=4c1144d857a5b2b80d45b8cf5138289579a9f8136aadfa6dd684b31fe2bc18c1
-  jekyll-archives (2.3.0) sha256=2dbd8ce22212fbace81fe2c9aa4152a6e21c748bcc626f135af5acfd813375f6
+  jekyll-paginate-v2 (3.0.0) sha256=001be6c1963caa41fed9c2f43b0d47201defa0395381eb8830487c1c2fc4f4e3
   jekyll-sass-converter (3.1.0) sha256=83925d84f1d134410c11d0c6643b0093e82e3a3cf127e90757a85294a3862443
   jekyll-seo-tag (2.9.0) sha256=0260015a8e1df9bf195cdfb0c675b7b2883fd8cbf12556e1c1cbe36a831c6852
   jekyll-sitemap (1.4.0) sha256=0de08c5debc185ea5a8f980e1025c7cd3f8e0c35c8b6ef592f15c46235cf4218

--- a/_config.yml
+++ b/_config.yml
@@ -55,11 +55,13 @@ defaults:
     values:
       locale: en_US
   # KNOWN GAP: this does not reach the nine /category/ pages, which still emit the
-  # bare `og:locale: en`. jekyll-archives builds them itself and applies no
-  # front-matter defaults, so neither the scope above nor a `type: archives` scope
-  # touches them — the latter was tried and changed nothing. Fixing it properly
-  # needs a _plugins/ hook, which is more machinery than an Open Graph locale on a
-  # category listing is worth. Recorded rather than papered over.
+  # bare `og:locale: en`. They are built by a generator that constructs its own
+  # page objects and applies no front-matter defaults, so neither the scope above
+  # nor a type-scoped one touches them — that was tried under jekyll-archives and
+  # changed nothing, and jekyll-paginate-v2's autopages behaves the same way for
+  # the same reason. Fixing it properly needs a _plugins/ hook, which is more
+  # machinery than an Open Graph locale on a category listing is worth. Recorded
+  # rather than papered over.
   - scope:
       path: ""
       type: posts
@@ -152,19 +154,86 @@ plugins:
   # the source, and this repo hand-writes one (RSS 2.0 rather than the Atom the gem
   # emits). The gem has been inert since the day feed.xml was committed.
   - jekyll-sitemap
-  - jekyll-archives
+  - jekyll-paginate-v2
   - jekyll-seo-tag
 
-# Archives.
-# NOTE: jekyll-archives is not on GitHub Pages' plugin allowlist, so this block is
-# inert on the legacy builder and every /category/:name/ link 404s. It starts
-# working once the build moves to GitHub Actions with this repo's own Gemfile.
-jekyll-archives:
-  enabled:
-    - categories
-  layout: archive
-  permalinks:
-    category: '/category/:name/'
+# Pagination.
+#
+# This is jekyll-paginate-v2, not the v1 gem that used to be here. v1 populated
+# paginator.posts straight from site.posts with no filter hook, so `hidden: true`
+# posts had to be skipped inside the Liquid loop and the pages came out ragged
+# (6, 4, 6, 5) — which is why pagination was dropped from the site entirely. v2
+# rejects hidden documents in the generator, so paginator.posts is already the
+# visible set and every page is full.
+#
+# `enabled: true` here only supplies the defaults. A page is paginated only when it
+# opts in from its own front matter, which is what keeps /about, /topics/ and
+# /archive/ out of it — see index.html.
+#
+# Not on GitHub Pages' plugin allowlist; works because this repo controls its own
+# build via GitHub Actions.
+pagination:
+  enabled: true
+  per_page: 6
+  # These exact URLs were live until pagination was removed, so this restores them
+  # rather than minting /page/2/ and leaving the old ones 404ing. It matches the
+  # gem's code default; the README documents '/page/:num/' instead, so setting it
+  # explicitly is what stops a future README-led edit from silently moving them.
+  permalink: '/page:num/'
+  # ':title' means "leave page.title alone", and it has to be said out loud: the
+  # gem's own default is ':title - page :num', so omitting this key is NOT the same
+  # as switching it off. That default broke two things at once — jekyll-seo-tag
+  # already prefixes paginated pages itself, so the <title> came out "Page 2 of 4
+  # for Home - page 2", and _layouts/archive.html renders page.title as its <h1>,
+  # so category page 2 was headed "Posts tagged cnn - page 2". Titles are still
+  # unique per page; seo-tag supplies the "Page 2 of 4 for" part.
+  title: ':title'
+  sort_field: 'date'
+  # REQUIRED, and easy to miss: the generator sorts ascending and reverses only
+  # when this is true, and it defaults to FALSE. Omit it and the home page opens
+  # with the 2022 padding post instead of the newest one.
+  sort_reverse: true
+  # A window, not the full list: the control stays a fixed width as the blog grows.
+  # Also required — both bounds default to 0, and at 0/0 the gem never builds
+  # paginator.page_trail at all, so _includes/pagination.html renders no numbers.
+  trail:
+    before: 2
+    after: 2
+
+# Category archives, previously jekyll-archives.
+#
+# Swapped because both generators write the same /category/<name>/ permalinks and
+# would collide, so only one of them can be installed. Autopages produces the same
+# nine URLs and additionally paginates them through the block above.
+autopages:
+  enabled: true
+  categories:
+    layouts:
+      - 'archive.html'
+    # The bare category name, matching what jekyll-archives put in page.title.
+    # _layouts/archive.html renders it as the <h1> and jekyll-seo-tag uses it as the
+    # <title>; the ':title - page :num' suffix above is appended from page 2 on.
+    title: ':cat'
+    # The trailing slash is load-bearing. The plugin's own default is
+    # '/category/:cat' with no slash, which writes category/cnn.html instead of
+    # category/cnn/index.html and 404s all nine existing URLs.
+    permalink: '/category/:cat/'
+    slugify:
+      mode: 'default'
+      case: false
+  # Both explicitly off. The plugin's README says omitting a block disables it; that
+  # is not true of 3.0.0, which falls back to its built-in defaults and tries to
+  # build the pages anyway — "AutoPages: Generating collections pages" followed by
+  # four `Layout 'autopage_collection' requested` warnings, because the layout it
+  # defaults to does not exist here. Only `enabled: false` actually stops them.
+  #
+  # Worth keeping off beyond the noise: the site has no tags, and tag autopages are
+  # the one code path with a reported Errno::EEXIST crash under Jekyll 4 (upstream
+  # issue #170).
+  tags:
+    enabled: false
+  collections:
+    enabled: false
 
 # Dependencies
 markdown: kramdown

--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -1,0 +1,55 @@
+{%- comment -%}
+  Shared by the home page and the /category/<name>/ autopages.
+
+  Every branch that has nowhere to link emits a <span>, never an <a>. The version
+  of this include that was deleted along with jekyll-paginate v1 linked page 1 to
+  paginator.previous_page_path, which is empty on page 1 — i.e. href="". That is a
+  hard failure in the html-proofer step, and it is the reason this file is written
+  fresh rather than restored.
+
+  paginator.page_trail is the window configured by `pagination.trail` in
+  _config.yml, so the control stays a fixed width instead of growing a number per
+  page as the blog does. Leave `trail` unset and both bounds default to 0, at which
+  point the plugin never builds page_trail at all and this loop silently renders no
+  numbers.
+
+  `| replace: 'index.html', ''` is load-bearing, not tidying. The trail's paths come
+  from the paginator's page_path, which is run through the plugin's ensure_full_path
+  and so always carries the index file — "/index.html", "/page2/index.html" — while
+  previous_page_path and next_page_path are built from the raw permalink and come
+  back clean as "/" and "/page2/". Left alone, this one nav would offer two
+  different URLs for the same page, and the ugly one is not the one in sitemap.xml.
+
+  aria-label is not decorative: _layouts/default.html already emits the
+  .mediumnavigation landmark, and two unlabelled <nav>s is a WCAG failure that the
+  pa11y-ci gate would catch.
+{%- endcomment -%}
+{%- if paginator.total_pages > 1 %}
+<nav class="post-pagination" aria-label="Pagination">
+  <ul class="post-pagination__list">
+    <li>
+      {%- if paginator.previous_page_path %}
+      <a class="post-pagination__link" rel="prev" href="{{ paginator.previous_page_path | relative_url }}">&laquo; Newer</a>
+      {%- else %}
+      <span class="post-pagination__link post-pagination__link--disabled">&laquo; Newer</span>
+      {%- endif %}
+    </li>
+    {%- for trail in paginator.page_trail %}
+    <li>
+      {%- if trail.num == paginator.page %}
+      <span class="post-pagination__link post-pagination__link--current" aria-current="page">{{ trail.num }}</span>
+      {%- else %}
+      <a class="post-pagination__link" href="{{ trail.path | replace: 'index.html', '' | relative_url }}" aria-label="Page {{ trail.num }}">{{ trail.num }}</a>
+      {%- endif %}
+    </li>
+    {%- endfor %}
+    <li>
+      {%- if paginator.next_page_path %}
+      <a class="post-pagination__link" rel="next" href="{{ paginator.next_page_path | relative_url }}">Older &raquo;</a>
+      {%- else %}
+      <span class="post-pagination__link post-pagination__link--disabled">Older &raquo;</span>
+      {%- endif %}
+    </li>
+  </ul>
+</nav>
+{%- endif %}

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -2,22 +2,30 @@
 layout: default
 ---
 {%- comment -%}
-  Used by jekyll-archives for the /category/<name>/ pages.
+  Used by jekyll-paginate-v2's autopages generator for the /category/<name>/
+  pages, configured under `autopages:` in _config.yml. It replaced jekyll-archives,
+  which wrote the same permalinks and could not paginate them.
 
-  page.posts is filtered on `hidden` so these pages agree with the homepage,
-  /topics/ and /archive/. jekyll-archives itself offers no filter hook, so it
-  has to happen here.
+  paginator.posts, NOT page.posts. Autopages hands the posts over through the
+  paginator and sets no page.posts at all, so leaving the old key here would send
+  all nine categories down the empty-state branch below — with valid HTML, a green
+  html-proofer run and a 200 from the smoke job. That failure is silent, so it is
+  worth spelling out.
 
-  `title` is deliberately not set in front matter: jekyll-archives supplies the
-  category name as page.title, and hardcoding it would override every archive
-  page with the same heading and feed jekyll-seo-tag the wrong <title>.
+  No `hidden` filter either: the generator rejects hidden documents itself, which
+  is the job this line used to do by hand.
+
+  `title` is deliberately not set in front matter: autopages supplies the category
+  name as page.title (`title: ':cat'` in _config.yml, matching what jekyll-archives
+  supplied), and hardcoding it would override every archive page with the same
+  heading and feed jekyll-seo-tag the wrong <title>.
 {%- endcomment -%}
-{%- assign posts = page.posts | where_exp: "p", "p.hidden != true" -%}
+{%- assign posts = paginator.posts -%}
 {%- comment -%}
   An empty category page is marked noindex, but that has to happen in
   _layouts/default.html: Jekyll renders this layout first and hands the result to
   the parent as `content`, so a variable assigned here never reaches its <head>.
-  default.html recomputes the same filter over page.posts.
+  default.html keys off paginator.total_posts instead.
 {%- endcomment -%}
 
 <!-- Begin List Posts
@@ -53,4 +61,10 @@ layout: default
   {%- else %}
   <p>Nothing published under this topic yet. <a href="{{ '/topics/' | relative_url }}">Browse all topics</a>.</p>
   {%- endif %}
+
+  {%- comment -%}
+    The same control the home page uses. It renders nothing at all when a category
+    fits on one page, which is six of the nine today.
+  {%- endcomment -%}
+  {% include pagination.html %}
 </section>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,20 +26,29 @@
 
         - `hidden: true` posts. Eight surfaces filter them, but jekyll-sitemap knows
           nothing about the flag, so every one was submitted to search engines.
-        - Category pages whose only posts are hidden. jekyll-archives builds a page
-          per category from the unfiltered list, so /category/android/ is a live URL
-          reading "Nothing published under this topic yet". Computed here rather than
-          in _layouts/archive.html because that layout's output becomes this one's
-          `content` — a variable assigned there never reaches this <head>.
+        - Category pages with nothing visible in them, which are built from the
+          unfiltered category list and render "Nothing published under this topic
+          yet". Computed here rather than in _layouts/archive.html because that
+          layout's output becomes this one's `content` — a variable assigned there
+          never reaches this <head>.
+
+      The empty-category test reads paginator.total_posts, not page.posts. Category
+      pages come from jekyll-paginate-v2's autopages now, which pass their posts
+      through the paginator and set no page.posts at all, so the old key is never
+      populated. No category is empty today — the one that was, /category/android/,
+      went away with the post that created it — so this is a net kept in place for
+      the next time, not a live fix.
+
+      paginator is nil on unpaginated pages, so `nil == 0` is false and they are
+      untouched. Paginated home pages have total_posts > 0 and stay indexable, which
+      is deliberate: noindex on /page2/ … /page4/ would cut the crawl path to the
+      posts that only those pages link to.
 
       `follow` is deliberate: don't index the page, do keep crawling out of it.
     {%- endcomment -%}
     {%- assign noindex = false -%}
     {%- if page.hidden == true -%}{%- assign noindex = true -%}{%- endif -%}
-    {%- if page.posts -%}
-      {%- assign archive_visible = page.posts | where_exp: "p", "p.hidden != true" -%}
-      {%- if archive_visible.size == 0 -%}{%- assign noindex = true -%}{%- endif -%}
-    {%- endif -%}
+    {%- if paginator.total_posts == 0 -%}{%- assign noindex = true -%}{%- endif -%}
     {%- if noindex %}<meta name="robots" content="noindex, follow" />{% endif %}
     {%- comment -%}
       NOT {% feed_meta %}. That tag advertises the feed as application/atom+xml,
@@ -136,6 +145,25 @@
     {%- endcomment -%}
     <a class="skip-link visually-hidden-focusable" href="#main-content">Skip to content</a>
 
+    {%- comment -%}
+      "The home page" is now four URLs, not one: jekyll-paginate-v2 renders /,
+      /page2/, /page3/ and /page4/ from the same index.html through this layout.
+      Two things below keyed off `page.url == '/'` and so were wrong on pages 2+ —
+      the active state on the Blog nav item, and the .mainheading block that carries
+      the only <h1> those pages have. A paginated page with no <h1> at all is both
+      an accessibility defect and a crawler one.
+
+      The test is `paginator.first_page_path`, not a bare `paginator`: the
+      /category/<name>/ autopages have a paginator too, and matching them here would
+      put the site title above every category listing and light up the wrong nav
+      item. first_page_path is the URL that page's series starts at, so it is '/'
+      for exactly this series and '/category/<name>/' for those.
+    {%- endcomment -%}
+    {%- assign is_home = false -%}
+    {%- if page.url == '/' or paginator.first_page_path == '/' -%}
+      {%- assign is_home = true -%}
+    {%- endif -%}
+
     <!-- Begin Menu Navigation
 ================================================== -->
     <!-- No data-bs-theme here. Bootstrap 5.3 resolves it at the nearest ancestor,
@@ -176,8 +204,8 @@
           <ul class="navbar-nav ms-auto">
             <li class="nav-item">
               <a
-                class="nav-link{% if page.url == '/' %} active{% endif %}"
-                {% if page.url == '/' %}aria-current="page"{% endif %}
+                class="nav-link{% if is_home %} active{% endif %}"
+                {% if is_home %}aria-current="page"{% endif %}
                 href="{{ '/' | relative_url }}"
                 >Blog</a
               >
@@ -239,8 +267,11 @@
           sat between the navbar and the article. Two h1s per page is ambiguous to a
           screen reader and to a crawler deciding what the page is about; interior
           pages already name themselves.
+
+          "Home page" includes /page2/ … /page4/ — see the is_home note above. It is
+          the only <h1> those pages have.
         {%- endcomment -%}
-        {%- if page.url == '/' %}
+        {%- if is_home %}
         <div class="mainheading">
           <h1 class="sitetitle">{{ site.name }}</h1>
           <p class="lead">

--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -875,6 +875,75 @@ blockquote {
   opacity: 1; // Firefox dims placeholders by default, undoing the fix above
 }
 
+// --------------------------------------------------------------- pagination
+
+/*
+ * The pagination control from _includes/pagination.html, used by the home page
+ * and the /category/<name>/ listings.
+ *
+ * Deliberately NOT named `.pagination`. screen.css line 620 declares
+ * `.pagination { display: block }`, and _layouts/default.html links screen.css
+ * after the Bootstrap CDN — so that vendored rule beats Bootstrap's own
+ * `display: flex` on load order alone. Anything given that class name here would
+ * inherit a fight with a file this repo does not edit by convention.
+ *
+ * The pill is the same 999px / 1px $rule / $accent idiom as .post-tag and
+ * .topic-cloud a: three chip rows on one site should read as one widget.
+ *
+ * Placed after the contrast section because --disabled uses $muted-aa, and Sass
+ * resolves variables in source order.
+ */
+.post-pagination {
+  margin: 1.5rem 0 0.5rem;
+}
+
+.post-pagination__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.4rem;
+}
+
+// One geometry for all three states, so the row does not resize as the current
+// page moves along it or a direction runs out. 44px is the comfortable touch
+// target; WCAG 2.2's floor is 24px.
+.post-pagination__link {
+  display: inline-block;
+  min-width: 2.75rem;
+  min-height: 44px;
+  padding: 0.55rem 0.9rem;
+  border: 1px solid $rule;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  text-align: center;
+  text-decoration: none;
+  color: $accent;
+}
+
+a.post-pagination__link:hover {
+  background: #f6f8fa;
+  text-decoration: none;
+}
+
+// Filled rather than outlined: aria-current="page" marks the current page for a
+// screen reader, and a sighted reader never sees it. #fff on $accent is 14.5:1.
+.post-pagination__link--current {
+  background: $accent;
+  border-color: $accent;
+  color: #fff;
+  font-weight: 600;
+}
+
+// Still painted on screen even though it links nowhere, so it still has to clear
+// 4.5:1 — $muted-aa is the 5.74:1 value the rest of the site's small print uses.
+.post-pagination__link--disabled {
+  color: $muted-aa;
+}
+
 // ------------------------------------------------------------------- tables
 
 /*
@@ -988,6 +1057,7 @@ blockquote {
   .no-print,
   .series-nav,
   .PageNavigation,
+  .post-pagination,
   .post-read-more {
     display: none !important;
   }

--- a/_sass/_dark.scss
+++ b/_sass/_dark.scss
@@ -160,6 +160,35 @@ $link-hover: #a5d6ff;
     color: $text-muted;
   }
 
+  // The pagination pills, same split for the same reason: the numbered links and
+  // the prev/next arrows are <a>s and take $link from the blanket rule above,
+  // which nothing here can outrank, so only the box needs restating. The current
+  // page and an exhausted direction are <span>s and need explicit colours.
+  //
+  // These live here rather than beside the light rules in _components.scss
+  // because that !important `a` is the whole constraint — a dark link colour
+  // written into an earlier module simply would not apply.
+  .post-pagination__link {
+    border-color: $rule;
+  }
+
+  a.post-pagination__link:hover {
+    background: #21262d;
+  }
+
+  // $text on #21262d is 9.9:1; the $link border is what marks it as current for a
+  // sighted reader, matching the filled pill in light mode.
+  .post-pagination__link--current {
+    background: #21262d;
+    border-color: $link;
+    color: $text;
+  }
+
+  // $text-muted on $bg is 6.2:1.
+  .post-pagination__link--disabled {
+    color: $text-muted;
+  }
+
   // Same split for the translation switcher: the label is a <span> and needs a
   // colour, the link is an <a> and already has one it cannot lose.
   .post-translations__label {

--- a/index.html
+++ b/index.html
@@ -5,6 +5,11 @@ title: Home
 # URL people actually paste into Slack, LinkedIn and X — was the one page on the
 # site with no og:image, and previewed as a bare grey card.
 image: /assets/images/logo.png
+# Opt in to jekyll-paginate-v2. Its _config.yml block only supplies defaults;
+# without this key the page renders unpaginated, which is exactly what keeps
+# /about, /topics/ and /archive/ out of it.
+pagination:
+  enabled: true
 ---
 
 {%- comment -%}
@@ -12,15 +17,26 @@ image: /assets/images/logo.png
   read by nothing, so stubs and drafts sat on the front page. Both are honoured
   here.
 
-  Pagination is gone deliberately: jekyll-paginate v1 populates paginator.posts
-  from site.posts unconditionally and offers no filter hook, so filtering inside
-  the loop produced ragged pages of 6, 4, 6, 5. With 23 visible posts, one page
-  is the right answer anyway.
+  Pagination is back, on jekyll-paginate-v2 rather than the v1 gem that was here
+  before. v1 populated paginator.posts from site.posts unconditionally with no
+  filter hook, so `hidden: true` had to be filtered inside the loop below and the
+  pages came out ragged (6, 4, 6, 5) — which is why it was removed. v2 rejects
+  hidden documents in the generator itself, so paginator.posts is already the
+  visible set and no `hidden` filter belongs in this file any more.
+
+  The Featured block and the de-duplication below are both gated on page 1, and
+  gating them TOGETHER is the point. Gate only the block, and a featured post that
+  ever fell outside page 1's slice would vanish from the site entirely: the dedupe
+  would still skip it while nothing rendered it. Gated together, such a post just
+  appears as an ordinary card on whichever page it lands on.
 {%- endcomment -%}
 
-{%- assign visible  = site.posts | where_exp: "p", "p.hidden != true" -%}
-{%- assign featured = visible | where_exp: "p", "p.featured == true" | slice: 0, 2 -%}
-{%- assign featured_urls = featured | map: "url" | join: "," -%}
+{%- assign featured_urls = '' -%}
+{%- if paginator.page == 1 -%}
+  {%- assign visible  = site.posts | where_exp: "p", "p.hidden != true" -%}
+  {%- assign featured = visible | where_exp: "p", "p.featured == true" | slice: 0, 2 -%}
+  {%- assign featured_urls = featured | map: "url" | join: "," -%}
+{%- endif -%}
 
 {%- if featured.size > 0 %}
 <section class="featured-posts">
@@ -44,16 +60,18 @@ image: /assets/images/logo.png
 
   <div class="row listrecent">
     {%- comment -%}
-      Featured posts are skipped so nothing renders twice.
+      Featured posts are skipped so nothing renders twice. featured_urls is empty
+      on pages 2+, so nothing is skipped there.
 
       `first_card` marks the first card actually rendered, which postbox.html uses
       for its eager/high-priority image hint. It cannot use forloop.first: this
       loop starts at the newest visible post, which is normally featured and
       therefore skipped, so forloop.first was true for a card that never rendered
-      and every real card ended up lazy — including the LCP element.
+      and every real card ended up lazy — including the LCP element. The counter
+      restarts on each paginated page, so every page marks its own LCP card.
     {%- endcomment -%}
     {%- assign rendered = 0 -%}
-    {%- for post in visible -%}
+    {%- for post in paginator.posts -%}
       {%- unless featured_urls contains post.url -%}
         {%- if rendered == 0 -%}
           {%- include postbox.html first_card=true -%}
@@ -64,4 +82,6 @@ image: /assets/images/logo.png
       {%- endunless -%}
     {%- endfor %}
   </div>
+
+  {% include pagination.html %}
 </section>


### PR DESCRIPTION
## What changed

Adds `jekyll-paginate-v2`, paginating both the home page (`/`, `/page2/`, `/page3/`, `/page4/` at 6 cards each) and the `/category/<name>/` archives. It **replaces** `jekyll-archives` rather than joining it — v2's autopages generator writes the same `/category/<name>/` permalinks, so the two would collide, and it paginates them as well.

All nine category URLs are unchanged. The three large ones (`cnn`, `computer-vision`, `deep-learning`) now run to three pages each; the other six fit on one page and render no nav at all.

## Why

Pagination was removed in 95df682 because jekyll-paginate **v1** filled `paginator.posts` from `site.posts` unconditionally with no filter hook — so `hidden: true` had to be handled inside the Liquid loop and the pages came out ragged (6, 4, 6, 5). v2 rejects hidden documents in the generator itself:

```ruby
# paginationModel.rb
docs = docs.reject { |doc| doc['hidden'] }
```

That removes the reason it was dropped. `/page2/`–`/page4/` return to the URLs they previously had rather than minting `/page/2/`.

### Three things the plugin's README gets wrong

All three were found by building, not by reading:

- **Omitting the `tags:`/`collections:` autopage blocks does not disable them.** 3.0.0 falls back to its own defaults and tries to build both, warning four times about a layout that does not exist here. Only `enabled: false` stops them.
- **`title:` defaults to `':title - page :num'`**, so leaving it out is not the same as leaving it alone. jekyll-seo-tag already prefixes paginated pages, so titles read `Page 2 of 4 for Home - page 2`, and `archive.html` renders `page.title` as its `<h1>`, so category page 2 was headed *"Posts tagged cnn - page 2"*. Set to `':title'`.
- **`sort_reverse` defaults to `false` and `trail` to `0/0`.** Without the first the home page opens with the 2022 padding post; without the second `paginator.page_trail` is never built and the numbered links render nothing.

### Design notes

- The Featured block and the de-duplication it needs are gated on page 1 **together**. Gating only the block would let a featured post that aged out of page 1's slice vanish from the site, since the dedupe would still skip it while nothing rendered it.
- `_layouts/default.html` keyed the active nav item and the `.mainheading` `<h1>` off `page.url == '/'`, which left `/page2/` with **no `<h1>` at all**. Now keyed off `paginator.first_page_path`, which is `/` for this series and `/category/<name>/` for the autopages — so category pages correctly do not match.
- The empty-archive noindex moves from `page.posts`, which autopages never sets, to `paginator.total_posts`. Nothing is empty today; it is a net.
- `_includes/pagination.html` is written fresh, not restored. The deleted one linked page 1 to `paginator.previous_page_path`, which is empty on page 1 — the empty `href` html-proofer fails on. It also normalises the trail's paths, which come back as `/page2/index.html` while prev/next give `/page2/`, so one nav offered two URLs per page.
- Class is `.post-pagination`, not `.pagination`: `screen.css:620` declares `.pagination { display: block }` and loads after the Bootstrap CDN, so that vendored rule beats Bootstrap's flex layout.

## Verified locally

- `bundle exec jekyll build --trace` exits 0 with no warnings
- 24 posts across the 4 home pages, no duplicates, hidden post excluded; 17 across `cnn`'s 3
- 13 pages carry the nav; all 13 link targets resolve; no empty `href`s anywhere
- `script/lint-content.rb` passes
- Every pill colour ≥5.7:1 in both themes (lowest is 5.74:1 light / 6.15:1 dark)

**Not verified locally:** html-proofer cannot run on Windows (libcurl, as `ci.yml` notes) and Node is not installed here, so **pa11y never ran** — the accessibility gate on the new nav markup is untested until CI. `/page2/` and `/category/cnn/` were added to the pa11y URL list for that reason, and the `pages.yml` smoke job gained a card-count assertion, since a bare `200` would pass on a category page reading *"Nothing published under this topic yet."*

## Checklist

- [x] `bundle exec jekyll build` succeeds locally
- [x] No post URLs changed (or redirects are in place)
- [x] Checked on mobile and desktop widths if this touches layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)